### PR TITLE
fitToElements: Implemented concatenation of overlays and annotations

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -44,8 +44,8 @@
 |---|---|---|
 | `animateToRegion` | `region: Region`, `duration: Number` | 
 | `animateToCoordinate` | `region: Coordinate`, `duration: Number` | 
-| `fitToElements` | `animated: Boolean` | 
-
+| `fitToElements` | `animated: Boolean` | Fits both markers and overlays on the map
+| `fitToMarkers` | `animated: Boolean` | Fits markers on the map
 
 
 ## Types

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -104,7 +104,9 @@ RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
         if (![view isKindOfClass:[AIRMap class]]) {
             RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
         } else {
-            [(AIRMap *)view setRegion:region animated:YES];
+            [AIRMap animateWithDuration:duration/1000 animations:^{
+                [(AIRMap *)view setRegion:region animated:YES];
+            }];
         }
     }];
 }
@@ -122,7 +124,9 @@ RCT_EXPORT_METHOD(animateToCoordinate:(nonnull NSNumber *)reactTag
             MKCoordinateRegion region;
             region.span = mapView.region.span;
             region.center = latlng;
-            [mapView setRegion:region animated:YES];
+            [AIRMap animateWithDuration:duration/1000 animations:^{
+                [mapView setRegion:region animated:YES];
+            }];
         }
     }];
 }

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -140,8 +140,24 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
             RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
         } else {
             AIRMap *mapView = (AIRMap *)view;
-            // TODO(lmr): we potentially want to include overlays here... and could concat the two arrays together.
-            [mapView showAnnotations:mapView.annotations animated:animated];
+
+            MKMapRect concatedMapRect = MKMapRectNull;
+            
+            for( id<MKOverlay>overlay  in mapView.overlays){
+                
+                concatedMapRect = MKMapRectUnion(concatedMapRect, [overlay boundingMapRect]);
+            }
+            
+            for( id<MKAnnotation>annot in mapView.annotations){
+                
+                MKMapPoint point = MKMapPointForCoordinate(annot.coordinate);
+                
+                concatedMapRect = MKMapRectUnion(concatedMapRect, MKMapRectMake(point.x, point.y, 1, 1));
+            }
+            
+            [mapView setVisibleMapRect:concatedMapRect
+                           edgePadding:UIEdgeInsetsMake(10.0f, 10.0f, 10.0f, 10.0f)
+                              animated:animated];
         }
     }];
 }

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -104,9 +104,7 @@ RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
         if (![view isKindOfClass:[AIRMap class]]) {
             RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
         } else {
-            [AIRMap animateWithDuration:duration/1000 animations:^{
-                [(AIRMap *)view setRegion:region animated:YES];
-            }];
+            [(AIRMap *)view setRegion:region animated:YES];
         }
     }];
 }
@@ -124,9 +122,7 @@ RCT_EXPORT_METHOD(animateToCoordinate:(nonnull NSNumber *)reactTag
             MKCoordinateRegion region;
             region.span = mapView.region.span;
             region.center = latlng;
-            [AIRMap animateWithDuration:duration/1000 animations:^{
-                [mapView setRegion:region animated:YES];
-            }];
+            [mapView setRegion:region animated:YES];
         }
     }];
 }
@@ -140,7 +136,7 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
             RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
         } else {
             AIRMap *mapView = (AIRMap *)view;
-
+            
             MKMapRect concatedMapRect = MKMapRectNull;
             
             for( id<MKOverlay>overlay  in mapView.overlays){
@@ -158,6 +154,22 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
             [mapView setVisibleMapRect:concatedMapRect
                            edgePadding:UIEdgeInsetsMake(10.0f, 10.0f, 10.0f, 10.0f)
                               animated:animated];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(fitToMarkers:(nonnull NSNumber*)reactTag
+                  animated:(BOOL)animated)
+{
+    
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[AIRMap class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
+        } else {
+            AIRMap *mapView = (AIRMap *)view;
+            
+            [mapView showAnnotations:mapView.annotations animated:animated];
         }
     }];
 }


### PR DESCRIPTION
I've implemented the concatenation of overlays and annotations on iOS. I haven't tested out the new method for calculating the bounding rect for the annotations, because my app doesn't use individual annotations yet.
