### PR TITLE
Remove createJSModules(depricated) method from MapsPackage.java file

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -24,11 +24,6 @@ public class MapsPackage implements ReactPackage {
     return Arrays.<NativeModule>asList(new AirMapModule(reactContext));
   }
 
-  // Deprecated RN 0.47
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     AirMapCalloutManager calloutManager = new AirMapCalloutManager();


### PR DESCRIPTION
# Motivation 
According to [this document ](https://facebook.github.io/react-native/docs/native-modules-ios.html) of `react-native`  documentation, the createJSModules() method is deprecated and it is not needed. I removed this method from MapsPackage.java file.

# Test Plan
I removed this method from mentioned file and ran my app. There was no error and problem and my test app is working properly.