### PR TITLE
fixed region/initialRegion null overrides of this.props

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -659,10 +659,10 @@ class MapView extends React.Component {
         region: null,
         initialRegion: null,
         onMarkerPress: this._onMarkerPress,
-        ...this.props,
         onChange: this._onChange,
         onMapReady: this._onMapReady,
         onLayout: this._onLayout,
+        ...this.props,
       };
       if (Platform.OS === 'ios' && props.provider === ProviderConstants.PROVIDER_DEFAULT
         && GOOGLE_MAPS_ONLY_TYPES.includes(props.mapType)) {

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -656,10 +656,10 @@ class MapView extends React.Component {
 
     if (this.state.isReady) {
       props = {
-        ...this.props,
         region: null,
         initialRegion: null,
         onMarkerPress: this._onMarkerPress,
+        ...this.props,
         onChange: this._onChange,
         onMapReady: this._onMapReady,
         onLayout: this._onLayout,


### PR DESCRIPTION
I noticed that 
props.region and props.initialRegion are always come as null. (even if set for `<MapView />`)

This change gives ability to set `region` and `initialRegion` to something that come from the top. 

Also it causes big performance issue on RN side when these props are null, (I'll try to mitigate that with different PR)



