### PR TITLE
Add native animation for Markers on Android

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
@@ -8,6 +8,9 @@ import android.graphics.drawable.Animatable;
 import android.net.Uri;
 import android.view.View;
 import android.widget.LinearLayout;
+import android.animation.ObjectAnimator;
+import android.util.Property;
+import android.animation.TypeEvaluator;
 
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.DataSource;
@@ -215,6 +218,29 @@ public class AirMapMarker extends AirMapFeature {
       marker.setInfoWindowAnchor(calloutAnchorX, calloutAnchorY);
     }
     update();
+  }
+
+  public LatLng interpolate(float fraction, LatLng a, LatLng b) {
+    double lat = (b.latitude - a.latitude) * fraction + a.latitude;
+    double lng = (b.longitude - a.longitude) * fraction + a.longitude;
+    return new LatLng(lat, lng);
+  }
+
+  public void animateToCoodinate(LatLng finalPosition, Integer duration) {
+    TypeEvaluator<LatLng> typeEvaluator = new TypeEvaluator<LatLng>() {
+      @Override
+      public LatLng evaluate(float fraction, LatLng startValue, LatLng endValue) {
+        return interpolate(fraction, startValue, endValue);
+      }
+    };
+    Property<Marker, LatLng> property = Property.of(Marker.class, LatLng.class, "position");
+    ObjectAnimator animator = ObjectAnimator.ofObject(
+      marker,
+      property,
+      typeEvaluator,
+      finalPosition);
+    animator.setDuration(duration);
+    animator.start();
   }
 
   public void setImage(String uri) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
@@ -11,6 +11,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.LatLng;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,6 +22,7 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
 
   private static final int SHOW_INFO_WINDOW = 1;
   private static final int HIDE_INFO_WINDOW = 2;
+  private static final int ANIMATE_MARKER_TO_COORDINATE = 3;
 
   public AirMapMarkerManager() {
   }
@@ -154,12 +156,18 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
   public Map<String, Integer> getCommandsMap() {
     return MapBuilder.of(
         "showCallout", SHOW_INFO_WINDOW,
-        "hideCallout", HIDE_INFO_WINDOW
+        "hideCallout", HIDE_INFO_WINDOW,
+        "animateMarkerToCoordinate",  ANIMATE_MARKER_TO_COORDINATE
     );
   }
 
   @Override
   public void receiveCommand(AirMapMarker view, int commandId, @Nullable ReadableArray args) {
+    Integer duration;
+    Double lat;
+    Double lng;
+    ReadableMap region;
+
     switch (commandId) {
       case SHOW_INFO_WINDOW:
         ((Marker) view.getFeature()).showInfoWindow();
@@ -167,6 +175,14 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
 
       case HIDE_INFO_WINDOW:
         ((Marker) view.getFeature()).hideInfoWindow();
+        break;
+      case ANIMATE_MARKER_TO_COORDINATE:
+        region = args.getMap(0);
+        duration = args.getInt(1);
+  
+        lng = region.getDouble("longitude");
+        lat = region.getDouble("latitude");
+        view.animateToCoodinate(new LatLng(lat, lng), duration);
         break;
     }
   }

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -216,6 +216,7 @@ class MapMarker extends React.Component {
 
     this.showCallout = this.showCallout.bind(this);
     this.hideCallout = this.hideCallout.bind(this);
+    this.animateMarkerToCoordinate = this.animateMarkerToCoordinate.bind(this)
   }
 
   setNativeProps(props) {
@@ -228,6 +229,10 @@ class MapMarker extends React.Component {
 
   hideCallout() {
     this._runCommand('hideCallout', []);
+  }
+
+  animateMarkerToCoordinate(coordinate, duration) {
+      this._runCommand('animateMarkerToCoordinate', [coordinate, duration || 500]);
   }
 
   _getHandle() {

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -232,7 +232,7 @@ class MapMarker extends React.Component {
   }
 
   animateMarkerToCoordinate(coordinate, duration) {
-     this._runCommand('animateMarkerToCoordinate', [coordinate, duration || 500]);
+    this._runCommand('animateMarkerToCoordinate', [coordinate, duration || 500]);
   }
 
   _getHandle() {

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -216,7 +216,7 @@ class MapMarker extends React.Component {
 
     this.showCallout = this.showCallout.bind(this);
     this.hideCallout = this.hideCallout.bind(this);
-    this.animateMarkerToCoordinate = this.animateMarkerToCoordinate.bind(this)
+    this.animateMarkerToCoordinate = this.animateMarkerToCoordinate.bind(this);
   }
 
   setNativeProps(props) {
@@ -232,7 +232,7 @@ class MapMarker extends React.Component {
   }
 
   animateMarkerToCoordinate(coordinate, duration) {
-      this._runCommand('animateMarkerToCoordinate', [coordinate, duration || 500]);
+     this._runCommand('animateMarkerToCoordinate', [coordinate, duration || 500]);
   }
 
   _getHandle() {


### PR DESCRIPTION
Adds support for native marker animations on android. As of right now JS animations for multiple markers result in a poor performance as described at [#1765](https://github.com/airbnb/react-native-maps/issues/1765). This PR allows to animate up to 50 markers (depending on the device) with 60 fps on android.