### PR TITLE
Fix annotations added directly to AirMap view as subviews

### DIFF
--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -92,6 +92,14 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     [_regionChangeObserveTimer invalidate];
 }
 
+-(void)addSubview:(UIView *)view {
+    if([view isKindOfClass:[AIRMapMarker class]]) {
+        [self addAnnotation:(id <MKAnnotation>)view];
+    } else {
+        [super addSubview:view];
+    }
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)insertReactSubview:(id<RCTComponent>)subview atIndex:(NSInteger)atIndex {


### PR DESCRIPTION
Adapts RTCUIView+React lifecycle to MapKit API, when adding annotations (AirMapMarker).

Fixes:
https://github.com/airbnb/react-native-maps/issues/1844
https://github.com/airbnb/react-native-maps/pull/1405
https://github.com/airbnb/react-native-maps/issues/1393
https://github.com/airbnb/react-native-maps/issues/983
https://github.com/airbnb/react-native-maps/issues/865
https://github.com/airbnb/react-native-maps/pull/806
https://github.com/airbnb/react-native-maps/issues/751
https://github.com/airbnb/react-native-maps/issues/662
https://github.com/airbnb/react-native-maps/issues/553
#777, #561, #418, #314

Probably: 
https://github.com/airbnb/react-native-maps/issues/891

