### PR TITLE
Fixed onMapReady no longer getting called on iOS

### DIFF
--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -36,9 +36,6 @@ static NSString *const RCTMapViewKey = @"MapView";
 @end
 
 @implementation AIRMapManager
-{
-    BOOL didCallOnMapReady;
-}
   
 RCT_EXPORT_MODULE()
 
@@ -711,13 +708,10 @@ static int kDragCenterContext;
 
 - (void)mapViewWillStartRenderingMap:(AIRMap *)mapView
 {
-    if (!didCallOnMapReady)
-    {
-      didCallOnMapReady = YES;
-      mapView.onMapReady(@{});
+    if (!mapView.hasStartedRendering) {
+      mapView.onMapReady(@{}); 
+      mapView.hasStartedRendering = YES;
     }
-  
-    mapView.hasStartedRendering = YES;
     [mapView beginLoading];
     [self _emitRegionChangeEvent:mapView continuous:NO];
 }


### PR DESCRIPTION
Hi, this fixes onMapReady no longer getting called correctly in v0.18.x.

Due to this commit (https://github.com/airbnb/react-native-maps/pull/1797/files#diff-8a72baa08460d22c71989ddcbf76d49f), `onMapReady` was only called when the very first MapView was rendered for the very first time. After unmounting/mounting, or rendering any other MapView, onMapReady would be never called.