### PR TITLE
update GoogleMaps dependency to 2.5.0

### DIFF
--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-fno-modules'
 
   s.dependency 'React'
-  s.dependency 'GoogleMaps', '2.1.1'
+  s.dependency 'GoogleMaps', '2.5.0'
 end


### PR DESCRIPTION
this is to resolve compile error: Property 'cameraTargetBounds' not found on object of type 'AIRGoogleMap *'