### PR TITLE
#1859 onPress event for Polygon doesn't work on iOS

### DIFF
--- a/docs/polygon.md
+++ b/docs/polygon.md
@@ -14,6 +14,7 @@
 | `geodesic` | `Boolean` |  | Boolean to indicate whether to draw each segment of the line as a geodesic as opposed to straight lines on the Mercator projection. A geodesic is the shortest path between two points on the Earth's surface. The geodesic curve is constructed assuming the Earth is a sphere.
 | `lineDashPhase` | `Number` | `0` | (iOS only) The offset (in points) at which to start drawing the dash pattern. Use this property to start drawing a dashed line partway through a segment or gap. For example, a phase value of 6 for the patter 5-2-3-2 would cause drawing to begin in the middle of the first gap.
 | `lineDashPattern` | `Array<Number>` | `null` | (iOS only) An array of numbers specifying the dash pattern to use for the path. The array contains one or more numbers that indicate the lengths (measured in points) of the  line segments and gaps in the pattern. The values in the array alternate, starting with the first line segment length, followed by the first gap length, followed by the second line segment length, and so on.
+| `tappable` | `Bool` | false (for iOS) | Boolean to allow a polygon to be tappable and use the onPress function.
 
 ## Events
 


### PR DESCRIPTION
Because there is an undocumented props `tappable`
