### PR TITLE
#255 LocalTile overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ render() {
 
 ### Using a custom Tile Overlay
 
+#### Tile Overlay using tile server
+
 ```jsx
-<MapView 
+<MapView
   region={this.state.region}
   onRegionChange={this.onRegionChange}
 >
@@ -171,6 +173,33 @@ For Android: add the following line in your AndroidManifest.xml
 <uses-permission android:name="android.permission.INTERNET" />
 ```
 For IOS: configure [App Transport Security](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33) in your app
+
+#### Tile Overlay using local tiles
+
+Tiles can be stored locally within device using xyz tiling scheme and displayed as tile overlay as well. This is usefull especially for offline map usage when tiles are available for selected map region within device storage.
+
+```jsx
+<MapView
+  region={this.state.region}
+  onRegionChange={this.onRegionChange}
+>
+  <MapView.LocalTile
+   /**
+    * The path template of the locally stored tiles. The patterns {x} {y} {z} will be replaced at runtime
+    * For example, /storage/emulated/0/mytiles/{z}/{x}/{y}.png
+    */
+   pathTemplate={this.state.pathTemplate}
+   /**
+    * The size of provided local tiles (usually 256 or 512).
+    */
+   tileSize={256}
+  />
+</MapView>
+```
+
+For Android: if original (for example Google) tiles are not desirable (no need to download them when using offline tiles), set mapType to 'none'.
+
+See [OSM Wiki](https://wiki.openstreetmap.org/wiki/Category:Tile_downloading) for how to download tiles for offline usage.
 
 ### Customizing the map style
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,12 @@ Tiles can be stored locally within device using xyz tiling scheme and displayed 
 </MapView>
 ```
 
-For Android: if original (for example Google) tiles are not desirable (no need to download them when using offline tiles), set mapType to 'none'.
+For Android: LocalTile is still just overlay over original map tiles. It means that if device is online, underlying tiles will be still downloaded. If original tiles download/display is not desirable set mapType to 'none'. For example:
+```
+<MapView
+  mapType={Platform.OS == "android" ? "none" : "standard"}
+>
+```
 
 See [OSM Wiki](https://wiki.openstreetmap.org/wiki/Category:Tile_downloading) for how to download tiles for offline usage.
 

--- a/example/examples/CustomTilesLocal.js
+++ b/example/examples/CustomTilesLocal.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import {
+  StyleSheet,
+  View,
+  Text,
+  Dimensions,
+} from 'react-native';
+
+import MapView, { MAP_TYPES, PROVIDER_DEFAULT } from 'react-native-maps';
+
+const { width, height } = Dimensions.get('window');
+
+const ASPECT_RATIO = width / height;
+const LATITUDE = 37.78825;
+const LONGITUDE = -122.4324;
+const LATITUDE_DELTA = 0.0922;
+const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+
+class CustomTiles extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      region: {
+        latitude: LATITUDE,
+        longitude: LONGITUDE,
+        latitudeDelta: LATITUDE_DELTA,
+        longitudeDelta: LONGITUDE_DELTA,
+      },
+    };
+  }
+
+  get mapType() {
+    // MapKit does not support 'none' as a base map
+    return this.props.provider === PROVIDER_DEFAULT ?
+      MAP_TYPES.STANDARD : MAP_TYPES.NONE;
+  }
+
+  render() {
+    const { region } = this.state;
+    return (
+      <View style={styles.container}>
+        <MapView
+          provider={this.props.provider}
+          mapType={this.mapType}
+          style={styles.map}
+          initialRegion={region}
+        >
+          <MapView.LocalTile
+            pathTemplate="/path/to/locally/saved/tiles/{z}/{x}/{y}.png"
+            tileSize={256}
+            zIndex={-1}
+          />
+        </MapView>
+        <View style={styles.buttonContainer}>
+          <View style={styles.bubble}>
+            <Text>Custom Tiles Local</Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+}
+
+CustomTiles.propTypes = {
+  provider: MapView.ProviderPropType,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  bubble: {
+    flex: 1,
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 20,
+  },
+  latlng: {
+    width: 200,
+    alignItems: 'stretch',
+  },
+  button: {
+    width: 80,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    marginHorizontal: 10,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    marginVertical: 20,
+    backgroundColor: 'transparent',
+  },
+});
+
+module.exports = CustomTiles;

--- a/index.d.ts
+++ b/index.d.ts
@@ -143,6 +143,7 @@ declare namespace MapView {
 
     interface MapLocalTileProps {
         pathTemplate: string;
+        tileSize: number;
         zIndex?: number;
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,8 +136,13 @@ declare namespace MapView {
         lineDashPattern?: number[];
     }
 
-    interface MapUrlTitleProps {
+    interface MapUrlTileProps {
         urlTemplate: string;
+        zIndex?: number;
+    }
+
+    interface MapLocalTileProps {
+        pathTemplate: string;
         zIndex?: number;
     }
 
@@ -151,7 +156,8 @@ declare namespace MapView {
     export class Polyline extends React.Component<MapPolylineProps, any> {}
     export class Polygon extends React.Component<MapPolygonProps, any> {}
     export class Circle extends React.Component<MapCircleProps, any> {}
-    export class UrlTile extends React.Component<MapUrlTitleProps, any> {}
+    export class UrlTile extends React.Component<MapUrlTileProps, any> {}
+    export class LocalTile extends React.Component<MapLocalTileProps, any> {}
     export class Callout extends React.Component<MapCalloutProps, any> {}
 }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTile.java
@@ -19,13 +19,12 @@ public class AirMapLocalTile extends AirMapFeature {
 
     class AIRMapLocalTileProvider implements TileProvider {
         private static final int BUFFER_SIZE = 16 * 1024;
-        private int width, height;
+        private float tileSize;
         private String pathTemplate;
 
 
-        public AIRMapLocalTileProvider(int width, int height, String pathTemplate) {
-            this.width = width;
-            this.height = height;
+        public AIRMapLocalTileProvider(float tileSizet, String pathTemplate) {
+            this.tileSize = tileSizet;
             this.pathTemplate = pathTemplate;
         }
 
@@ -33,11 +32,15 @@ public class AirMapLocalTile extends AirMapFeature {
         public Tile getTile(int x, int y, int zoom) {
             byte[] image = readTileImage(x, y, zoom);
             Log.d("AirMapLocalTile", String.format("getTile(%s, %s, %s) -> %s", x, y, zoom, getTileFilename(x, y, zoom)));
-            return image == null ? TileProvider.NO_TILE : new Tile(this.width, this.height, image);
+            return image == null ? TileProvider.NO_TILE : new Tile((int)this.tileSize, (int)this.tileSize, image);
         }
 
         public void setPathTemplate(String pathTemplate) {
             this.pathTemplate = pathTemplate;
+        }
+
+        public void setTileSize(float tileSize) {
+            this.tileSize = tileSize;
         }
 
         private byte[] readTileImage(int x, int y, int zoom) {
@@ -84,6 +87,7 @@ public class AirMapLocalTile extends AirMapFeature {
     private AirMapLocalTile.AIRMapLocalTileProvider tileProvider;
 
     private String pathTemplate;
+    private float tileSize;
     private float zIndex;
 
     public AirMapLocalTile(Context context) {
@@ -107,6 +111,13 @@ public class AirMapLocalTile extends AirMapFeature {
         }
     }
 
+    public void setTileSize(float tileSize) {
+        this.tileSize = tileSize;
+        if (tileProvider != null) {
+            tileProvider.setTileSize(tileSize);
+        }
+    }
+
     public TileOverlayOptions getTileOverlayOptions() {
         if (tileOverlayOptions == null) {
             tileOverlayOptions = createTileOverlayOptions();
@@ -117,7 +128,7 @@ public class AirMapLocalTile extends AirMapFeature {
     private TileOverlayOptions createTileOverlayOptions() {
         TileOverlayOptions options = new TileOverlayOptions();
         options.zIndex(zIndex);
-        this.tileProvider = new AirMapLocalTile.AIRMapLocalTileProvider(256, 256, this.pathTemplate);
+        this.tileProvider = new AirMapLocalTile.AIRMapLocalTileProvider(this.tileSize, this.pathTemplate);
         options.tileProvider(this.tileProvider);
         return options;
     }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTile.java
@@ -1,0 +1,139 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.Tile;
+import com.google.android.gms.maps.model.TileOverlay;
+import com.google.android.gms.maps.model.TileOverlayOptions;
+import com.google.android.gms.maps.model.TileProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class AirMapLocalTile extends AirMapFeature {
+
+    class AIRMapLocalTileProvider implements TileProvider {
+        private static final int BUFFER_SIZE = 16 * 1024;
+        private int width, height;
+        private String pathTemplate;
+
+
+        public AIRMapLocalTileProvider(int width, int height, String pathTemplate) {
+            this.width = width;
+            this.height = height;
+            this.pathTemplate = pathTemplate;
+        }
+
+        @Override
+        public Tile getTile(int x, int y, int zoom) {
+            byte[] image = readTileImage(x, y, zoom);
+            Log.d("AirMapLocalTile", String.format("getTile(%s, %s, %s) -> %s", x, y, zoom, getTileFilename(x, y, zoom)));
+            return image == null ? TileProvider.NO_TILE : new Tile(this.width, this.height, image);
+        }
+
+        public void setPathTemplate(String pathTemplate) {
+            this.pathTemplate = pathTemplate;
+        }
+
+        private byte[] readTileImage(int x, int y, int zoom) {
+            InputStream in = null;
+            ByteArrayOutputStream buffer = null;
+            File file = new File(getTileFilename(x, y, zoom));
+
+            try {
+                in = new FileInputStream(file);
+                buffer = new ByteArrayOutputStream();
+
+                int nRead;
+                byte[] data = new byte[BUFFER_SIZE];
+
+                while ((nRead = in.read(data, 0, BUFFER_SIZE)) != -1) {
+                    buffer.write(data, 0, nRead);
+                }
+                buffer.flush();
+
+                return buffer.toByteArray();
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            } catch (OutOfMemoryError e) {
+                e.printStackTrace();
+                return null;
+            } finally {
+                if (in != null) try { in.close(); } catch (Exception ignored) {}
+                if (buffer != null) try { buffer.close(); } catch (Exception ignored) {}
+            }
+        }
+
+        private String getTileFilename(int x, int y, int zoom) {
+            String s = this.pathTemplate
+                    .replace("{x}", Integer.toString(x))
+                    .replace("{y}", Integer.toString(y))
+                    .replace("{z}", Integer.toString(zoom));
+            return s;
+        }
+    }
+
+    private TileOverlayOptions tileOverlayOptions;
+    private TileOverlay tileOverlay;
+    private AirMapLocalTile.AIRMapLocalTileProvider tileProvider;
+
+    private String pathTemplate;
+    private float zIndex;
+
+    public AirMapLocalTile(Context context) {
+        super(context);
+    }
+
+    public void setPathTemplate(String pathTemplate) {
+        this.pathTemplate = pathTemplate;
+        if (tileProvider != null) {
+            tileProvider.setPathTemplate(pathTemplate);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setZIndex(float zIndex) {
+        this.zIndex = zIndex;
+        if (tileOverlay != null) {
+            tileOverlay.setZIndex(zIndex);
+        }
+    }
+
+    public TileOverlayOptions getTileOverlayOptions() {
+        if (tileOverlayOptions == null) {
+            tileOverlayOptions = createTileOverlayOptions();
+        }
+        return tileOverlayOptions;
+    }
+
+    private TileOverlayOptions createTileOverlayOptions() {
+        TileOverlayOptions options = new TileOverlayOptions();
+        options.zIndex(zIndex);
+        this.tileProvider = new AirMapLocalTile.AIRMapLocalTileProvider(256, 256, this.pathTemplate);
+        options.tileProvider(this.tileProvider);
+        return options;
+    }
+
+    @Override
+    public Object getFeature() {
+        return tileOverlay;
+    }
+
+    @Override
+    public void addToMap(GoogleMap map) {
+        this.tileOverlay = map.addTileOverlay(getTileOverlayOptions());
+    }
+
+    @Override
+    public void removeFromMap(GoogleMap map) {
+        tileOverlay.remove();
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTile.java
@@ -19,11 +19,11 @@ public class AirMapLocalTile extends AirMapFeature {
 
     class AIRMapLocalTileProvider implements TileProvider {
         private static final int BUFFER_SIZE = 16 * 1024;
-        private float tileSize;
+        private int tileSize;
         private String pathTemplate;
 
 
-        public AIRMapLocalTileProvider(float tileSizet, String pathTemplate) {
+        public AIRMapLocalTileProvider(int tileSizet, String pathTemplate) {
             this.tileSize = tileSizet;
             this.pathTemplate = pathTemplate;
         }
@@ -32,14 +32,14 @@ public class AirMapLocalTile extends AirMapFeature {
         public Tile getTile(int x, int y, int zoom) {
             byte[] image = readTileImage(x, y, zoom);
             Log.d("AirMapLocalTile", String.format("getTile(%s, %s, %s) -> %s", x, y, zoom, getTileFilename(x, y, zoom)));
-            return image == null ? TileProvider.NO_TILE : new Tile((int)this.tileSize, (int)this.tileSize, image);
+            return image == null ? TileProvider.NO_TILE : new Tile(this.tileSize, this.tileSize, image);
         }
 
         public void setPathTemplate(String pathTemplate) {
             this.pathTemplate = pathTemplate;
         }
 
-        public void setTileSize(float tileSize) {
+        public void setTileSize(int tileSize) {
             this.tileSize = tileSize;
         }
 
@@ -114,7 +114,7 @@ public class AirMapLocalTile extends AirMapFeature {
     public void setTileSize(float tileSize) {
         this.tileSize = tileSize;
         if (tileProvider != null) {
-            tileProvider.setTileSize(tileSize);
+            tileProvider.setTileSize((int)tileSize);
         }
     }
 
@@ -128,7 +128,7 @@ public class AirMapLocalTile extends AirMapFeature {
     private TileOverlayOptions createTileOverlayOptions() {
         TileOverlayOptions options = new TileOverlayOptions();
         options.zIndex(zIndex);
-        this.tileProvider = new AirMapLocalTile.AIRMapLocalTileProvider(this.tileSize, this.pathTemplate);
+        this.tileProvider = new AirMapLocalTile.AIRMapLocalTileProvider((int)this.tileSize, this.pathTemplate);
         options.tileProvider(this.tileProvider);
         return options;
     }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTile.java
@@ -1,7 +1,6 @@
 package com.airbnb.android.react.maps;
 
 import android.content.Context;
-import android.util.Log;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.Tile;
@@ -31,7 +30,6 @@ public class AirMapLocalTile extends AirMapFeature {
         @Override
         public Tile getTile(int x, int y, int zoom) {
             byte[] image = readTileImage(x, y, zoom);
-            Log.d("AirMapLocalTile", String.format("getTile(%s, %s, %s) -> %s", x, y, zoom, getTileFilename(x, y, zoom)));
             return image == null ? TileProvider.NO_TILE : new Tile(this.tileSize, this.tileSize, image);
         }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTileManager.java
@@ -43,7 +43,7 @@ public class AirMapLocalTileManager extends ViewGroupManager<AirMapLocalTile> {
         view.setPathTemplate(pathTemplate);
     }
 
-    @ReactProp(name = "zIndex", defaultFloat = 256f)
+    @ReactProp(name = "tileSize", defaultFloat = 256f)
     public void setTileSize(AirMapLocalTile view, float tileSize) {
         view.setTileSize(tileSize);
     }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTileManager.java
@@ -1,0 +1,51 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+/**
+ * Created by zavadpe on 30/11/2017.
+ */
+public class AirMapLocalTileManager extends ViewGroupManager<AirMapLocalTile> {
+    private DisplayMetrics metrics;
+
+    public AirMapLocalTileManager(ReactApplicationContext reactContext) {
+        super();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            metrics = new DisplayMetrics();
+            ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+                    .getDefaultDisplay()
+                    .getRealMetrics(metrics);
+        } else {
+            metrics = reactContext.getResources().getDisplayMetrics();
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "AIRMapLocalTile";
+    }
+
+    @Override
+    public AirMapLocalTile createViewInstance(ThemedReactContext context) {
+        return new AirMapLocalTile(context);
+    }
+
+    @ReactProp(name = "pathTemplate")
+    public void setPathTemplate(AirMapLocalTile view, String pathTemplate) {
+        view.setPathTemplate(pathTemplate);
+    }
+
+    @ReactProp(name = "zIndex", defaultFloat = -1.0f)
+    public void setZIndex(AirMapLocalTile view, float zIndex) {
+        view.setZIndex(zIndex);
+    }
+
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapLocalTileManager.java
@@ -43,6 +43,11 @@ public class AirMapLocalTileManager extends ViewGroupManager<AirMapLocalTile> {
         view.setPathTemplate(pathTemplate);
     }
 
+    @ReactProp(name = "zIndex", defaultFloat = 256f)
+    public void setTileSize(AirMapLocalTile view, float tileSize) {
+        view.setTileSize(tileSize);
+    }
+
     @ReactProp(name = "zIndex", defaultFloat = -1.0f)
     public void setZIndex(AirMapLocalTile view, float zIndex) {
         view.setZIndex(zIndex);

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -502,6 +502,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       AirMapUrlTile urlTileView = (AirMapUrlTile) child;
       urlTileView.addToMap(map);
       features.add(index, urlTileView);
+    } else if (child instanceof AirMapLocalTile) {
+      AirMapLocalTile localTileView = (AirMapLocalTile) child;
+      localTileView.addToMap(map);
+      features.add(index, localTileView);
     } else {
       ViewGroup children = (ViewGroup) child;
       for (int i = 0; i < children.getChildCount(); i++) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -38,7 +38,8 @@ public class MapsPackage implements ReactPackage {
     AirMapCircleManager circleManager = new AirMapCircleManager(reactContext);
     AirMapManager mapManager = new AirMapManager(reactContext);
     AirMapLiteManager mapLiteManager = new AirMapLiteManager(reactContext);
-    AirMapUrlTileManager tileManager = new AirMapUrlTileManager(reactContext);
+    AirMapUrlTileManager urlTileManager = new AirMapUrlTileManager(reactContext);
+    AirMapLocalTileManager localTileManager = new AirMapLocalTileManager(reactContext);
 
     return Arrays.<ViewManager>asList(
         calloutManager,
@@ -48,6 +49,7 @@ public class MapsPackage implements ReactPackage {
         circleManager,
         mapManager,
         mapLiteManager,
-        tileManager);
+        urlTileManager,
+        localTileManager);
   }
 }

--- a/lib/components/MapLocalTile.js
+++ b/lib/components/MapLocalTile.js
@@ -31,6 +31,8 @@ const propTypes = {
    * @platform android
    */
   zIndex: PropTypes.number,
+  
+  tileSize: PropTypes.number,
 };
 
 class MapLocalTile extends React.Component {

--- a/lib/components/MapLocalTile.js
+++ b/lib/components/MapLocalTile.js
@@ -1,0 +1,57 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {
+  ViewPropTypes,
+  View,
+} from 'react-native';
+
+import decorateMapComponent, {
+  USES_DEFAULT_IMPLEMENTATION,
+  SUPPORTED,
+} from './decorateMapComponent';
+
+// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
+const viewPropTypes = ViewPropTypes || View.propTypes;
+
+const propTypes = {
+  ...viewPropTypes,
+
+  /**
+   * The path template of the local tile source. The patterns {x} {y} {z} will be replaced at runtime
+   * For example, file::///storage/emulated/0/tiles/{z}/{x}/{y}.png
+   */
+  pathTemplate: PropTypes.string.isRequired,
+
+  /**
+   * The order in which this tile overlay is drawn with respect to other overlays. An overlay
+   * with a larger z-index is drawn over overlays with smaller z-indices. The order of overlays
+   * with the same z-index is arbitrary. The default zIndex is -1.
+   *
+   * @platform android
+   */
+  zIndex: PropTypes.number,
+};
+
+class MapLocalTile extends React.Component {
+  render() {
+    const AIRMapLocalTile = this.getAirComponent();
+    return (
+      <AIRMapLocalTile
+        {...this.props}
+      />
+    );
+  }
+}
+
+MapLocalTile.propTypes = propTypes;
+
+module.exports = decorateMapComponent(MapLocalTile, {
+  componentType: 'LocalTile',
+  providers: {
+    google: {
+      ios: SUPPORTED,
+      android: USES_DEFAULT_IMPLEMENTATION,
+    },
+  },
+});

--- a/lib/components/MapLocalTile.js
+++ b/lib/components/MapLocalTile.js
@@ -18,7 +18,7 @@ const propTypes = {
   ...viewPropTypes,
 
   /**
-   * The path template of the local tile source. 
+   * The path template of the local tile source.
    * The patterns {x} {y} {z} will be replaced at runtime,
    * for example, /storage/emulated/0/tiles/{z}/{x}/{y}.png.
    */

--- a/lib/components/MapLocalTile.js
+++ b/lib/components/MapLocalTile.js
@@ -18,8 +18,9 @@ const propTypes = {
   ...viewPropTypes,
 
   /**
-   * The path template of the local tile source. The patterns {x} {y} {z} will be replaced at runtime
-   * For example, file::///storage/emulated/0/tiles/{z}/{x}/{y}.png
+   * The path template of the local tile source. 
+   * The patterns {x} {y} {z} will be replaced at runtime,
+   * for example, /storage/emulated/0/tiles/{z}/{x}/{y}.png.
    */
   pathTemplate: PropTypes.string.isRequired,
 
@@ -31,7 +32,10 @@ const propTypes = {
    * @platform android
    */
   zIndex: PropTypes.number,
-  
+
+  /**
+   * Size of tile images.
+   */
   tileSize: PropTypes.number,
 };
 

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -17,6 +17,7 @@ import MapPolygon from './MapPolygon';
 import MapCircle from './MapCircle';
 import MapCallout from './MapCallout';
 import MapUrlTile from './MapUrlTile';
+import MapLocalTile from './MapLocalTile';
 import AnimatedRegion from './AnimatedRegion';
 import {
   contextTypes as childContextTypes,
@@ -739,6 +740,7 @@ MapView.Polyline = MapPolyline;
 MapView.Polygon = MapPolygon;
 MapView.Circle = MapCircle;
 MapView.UrlTile = MapUrlTile;
+MapView.LocalTile = MapLocalTile;
 MapView.Callout = MapCallout;
 Object.assign(MapView, ProviderConstants);
 MapView.ProviderPropType = PropTypes.oneOf(Object.values(ProviderConstants));

--- a/lib/ios/AirMaps.xcodeproj/project.pbxproj
+++ b/lib/ios/AirMaps.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		1125B2E61C4AD3DA007D0023 /* AIRMapPolylineManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1125B2D61C4AD3DA007D0023 /* AIRMapPolylineManager.m */; };
 		1125B2F21C4AD445007D0023 /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1125B2F11C4AD445007D0023 /* SMCalloutView.m */; };
 		19DABC7F1E7C9D3C00F41150 /* RCTConvert+AirMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 19DABC7E1E7C9D3C00F41150 /* RCTConvert+AirMap.m */; };
+		628F81201FD16DF80058313A /* AIRMapLocalTile.m in Sources */ = {isa = PBXBuildFile; fileRef = 628F811F1FD16DF80058313A /* AIRMapLocalTile.m */; };
+		628F81231FD16EFA0058313A /* AIRMapLocalTileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 628F81221FD16EFA0058313A /* AIRMapLocalTileManager.m */; };
+		62AEC4D41FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m in Sources */ = {isa = PBXBuildFile; fileRef = 62AEC4D31FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m */; };
 		DA6C26381C9E2AFE0035349F /* AIRMapUrlTile.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6C26371C9E2AFE0035349F /* AIRMapUrlTile.m */; };
 		DA6C263E1C9E324A0035349F /* AIRMapUrlTileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6C263D1C9E324A0035349F /* AIRMapUrlTileManager.m */; };
 /* End PBXBuildFile section */
@@ -70,6 +73,11 @@
 		11FA5C511C4A1296003AC2EE /* libAirMaps.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAirMaps.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		19DABC7D1E7C9D3C00F41150 /* RCTConvert+AirMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+AirMap.h"; sourceTree = "<group>"; };
 		19DABC7E1E7C9D3C00F41150 /* RCTConvert+AirMap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+AirMap.m"; sourceTree = "<group>"; };
+		628F811E1FD16D780058313A /* AIRMapLocalTile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AIRMapLocalTile.h; sourceTree = "<group>"; };
+		628F811F1FD16DF80058313A /* AIRMapLocalTile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AIRMapLocalTile.m; sourceTree = "<group>"; };
+		628F81211FD16EAB0058313A /* AIRMapLocalTileManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AIRMapLocalTileManager.h; sourceTree = "<group>"; };
+		628F81221FD16EFA0058313A /* AIRMapLocalTileManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AIRMapLocalTileManager.m; sourceTree = "<group>"; };
+		62AEC4D31FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AIRMapLocalTileOverlay.m; path = AirMaps/AIRMapLocalTileOverlay.m; sourceTree = "<group>"; };
 		DA6C26361C9E2AFE0035349F /* AIRMapUrlTile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRMapUrlTile.h; sourceTree = "<group>"; };
 		DA6C26371C9E2AFE0035349F /* AIRMapUrlTile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRMapUrlTile.m; sourceTree = "<group>"; };
 		DA6C263C1C9E324A0035349F /* AIRMapUrlTileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRMapUrlTileManager.h; sourceTree = "<group>"; };
@@ -90,6 +98,7 @@
 		11FA5C481C4A1296003AC2EE = {
 			isa = PBXGroup;
 			children = (
+				62AEC4D31FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m */,
 				11FA5C531C4A1296003AC2EE /* AirMaps */,
 				11FA5C521C4A1296003AC2EE /* Products */,
 			);
@@ -140,6 +149,10 @@
 				DA6C26371C9E2AFE0035349F /* AIRMapUrlTile.m */,
 				DA6C263C1C9E324A0035349F /* AIRMapUrlTileManager.h */,
 				DA6C263D1C9E324A0035349F /* AIRMapUrlTileManager.m */,
+				628F811E1FD16D780058313A /* AIRMapLocalTile.h */,
+				628F811F1FD16DF80058313A /* AIRMapLocalTile.m */,
+				628F81211FD16EAB0058313A /* AIRMapLocalTileManager.h */,
+				628F81221FD16EFA0058313A /* AIRMapLocalTileManager.m */,
 			);
 			path = AirMaps;
 			sourceTree = "<group>";
@@ -200,6 +213,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				62AEC4D41FD5A0AA003225E0 /* AIRMapLocalTileOverlay.m in Sources */,
 				1125B2E31C4AD3DA007D0023 /* AIRMapPolygon.m in Sources */,
 				1125B2E41C4AD3DA007D0023 /* AIRMapPolygonManager.m in Sources */,
 				1125B2DB1C4AD3DA007D0023 /* AIRMapCallout.m in Sources */,
@@ -209,12 +223,14 @@
 				19DABC7F1E7C9D3C00F41150 /* RCTConvert+AirMap.m in Sources */,
 				1125B2E51C4AD3DA007D0023 /* AIRMapPolyline.m in Sources */,
 				DA6C263E1C9E324A0035349F /* AIRMapUrlTileManager.m in Sources */,
+				628F81201FD16DF80058313A /* AIRMapLocalTile.m in Sources */,
 				1125B2DA1C4AD3DA007D0023 /* AIRMap.m in Sources */,
 				1125B2DF1C4AD3DA007D0023 /* AIRMapCoordinate.m in Sources */,
 				1125B2F21C4AD445007D0023 /* SMCalloutView.m in Sources */,
 				1125B2E11C4AD3DA007D0023 /* AIRMapMarker.m in Sources */,
 				1125B2E21C4AD3DA007D0023 /* AIRMapMarkerManager.m in Sources */,
 				DA6C26381C9E2AFE0035349F /* AIRMapUrlTile.m in Sources */,
+				628F81231FD16EFA0058313A /* AIRMapLocalTileManager.m in Sources */,
 				1125B2DE1C4AD3DA007D0023 /* AIRMapCircleManager.m in Sources */,
 				1125B2DC1C4AD3DA007D0023 /* AIRMapCalloutManager.m in Sources */,
 			);

--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -17,6 +17,7 @@
 #import "AIRMapCircle.h"
 #import <QuartzCore/QuartzCore.h>
 #import "AIRMapUrlTile.h"
+#import "AIRMapLocalTile.h"
 
 const CLLocationDegrees AIRMapDefaultSpan = 0.005;
 const NSTimeInterval AIRMapRegionChangeObserveInterval = 0.1;
@@ -62,6 +63,7 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 
 - (instancetype)init
 {
+    NSLog(@"AirMap.init................");
     if ((self = [super init])) {
         _hasStartedRendering = NO;
         _reactSubviews = [NSMutableArray new];
@@ -110,6 +112,9 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     } else if ([subview isKindOfClass:[AIRMapUrlTile class]]) {
         ((AIRMapUrlTile *)subview).map = self;
         [self addOverlay:(id<MKOverlay>)subview];
+    } else if ([subview isKindOfClass:[AIRMapLocalTile class]]) {
+        ((AIRMapLocalTile *)subview).map = self;
+        [self addOverlay:(id<MKOverlay>)subview];
     } else {
         NSArray<id<RCTComponent>> *childSubviews = [subview reactSubviews];
         for (int i = 0; i < childSubviews.count; i++) {
@@ -134,6 +139,8 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     } else if ([subview isKindOfClass:[AIRMapCircle class]]) {
         [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[AIRMapUrlTile class]]) {
+        [self removeOverlay:(id <MKOverlay>) subview];
+    } else if ([subview isKindOfClass:[AIRMapLocalTile class]]) {
         [self removeOverlay:(id <MKOverlay>) subview];
     } else {
         NSArray<id<RCTComponent>> *childSubviews = [subview reactSubviews];

--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -63,7 +63,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 
 - (instancetype)init
 {
-    NSLog(@"AirMap.init................");
     if ((self = [super init])) {
         _hasStartedRendering = NO;
         _reactSubviews = [NSMutableArray new];

--- a/lib/ios/AirMaps/AIRMapLocalTile.h
+++ b/lib/ios/AirMaps/AIRMapLocalTile.h
@@ -1,0 +1,36 @@
+//
+//  AIRMapLocalTile.h
+//  AirMaps
+//
+//  Created by Peter Zavadsky on 01/12/2017.
+//  Copyright © 2017 Christopher. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <MapKit/MapKit.h>
+#import <UIKit/UIKit.h>
+
+#import <React/RCTComponent.h>
+#import <React/RCTView.h>
+#import "AIRMapCoordinate.h"
+#import "AIRMap.h"
+#import "RCTConvert+AirMap.h"
+
+@interface AIRMapLocalTile : MKAnnotationView <MKOverlay>
+
+@property (nonatomic, weak) AIRMap *map;
+
+@property (nonatomic, strong) MKTileOverlay *tileOverlay;
+@property (nonatomic, strong) MKTileOverlayRenderer *renderer;
+
+@property (nonatomic, copy) NSString *pathTemplate;
+@property (nonatomic, assign) CGFloat tileSize;
+
+#pragma mark MKOverlay protocol
+
+@property(nonatomic, readonly) CLLocationCoordinate2D coordinate;
+@property(nonatomic, readonly) MKMapRect boundingMapRect;
+//- (BOOL)intersectsMapRect:(MKMapRect)mapRect;
+- (BOOL)canReplaceMapContent;
+
+@end

--- a/lib/ios/AirMaps/AIRMapLocalTile.m
+++ b/lib/ios/AirMaps/AIRMapLocalTile.m
@@ -1,0 +1,71 @@
+//
+//  AIRMapLocalTile.m
+//  AirMaps
+//
+//  Created by Peter Zavadsky on 01/12/2017.
+//  Copyright © 2017 Christopher. All rights reserved.
+//
+
+#import "AIRMapLocalTile.h"
+#import <React/UIView+React.h>
+#import "AIRMapLocalTileOverlay.h"
+
+@implementation AIRMapLocalTile {
+    BOOL _pathTemplateSet;
+    BOOL _tileSizeSet;
+}
+
+
+- (void)setPathTemplate:(NSString *)pathTemplate{
+    NSLog(@"setPathTemplate %@", pathTemplate);
+    _pathTemplate = pathTemplate;
+    _pathTemplateSet = YES;
+    [self createTileOverlayAndRendererIfPossible];
+    [self update];
+}
+
+- (void)setTileSize:(CGFloat)tileSize{
+    NSLog(@"setTileSize %f", tileSize);
+    _tileSize = tileSize;
+    _tileSizeSet = YES;
+    [self createTileOverlayAndRendererIfPossible];
+    [self update];
+}
+
+- (void) createTileOverlayAndRendererIfPossible
+{
+    NSLog(@"createTileOverlayAndRendererIfPossible");
+    if (!_pathTemplateSet || !_tileSizeSet) return;
+    self.tileOverlay = [[AIRMapLocalTileOverlay alloc] initWithURLTemplate:self.pathTemplate];
+    self.tileOverlay.canReplaceMapContent = YES;
+    self.tileOverlay.tileSize = CGSizeMake(_tileSize, _tileSize);
+    self.renderer = [[MKTileOverlayRenderer alloc] initWithTileOverlay:self.tileOverlay];
+}
+
+- (void) update
+{
+    if (!_renderer) return;
+    
+    if (_map == nil) return;
+    [_map removeOverlay:self];
+    [_map addOverlay:self level:MKOverlayLevelAboveLabels];
+}
+
+#pragma mark MKOverlay implementation
+
+- (CLLocationCoordinate2D) coordinate
+{
+    return self.tileOverlay.coordinate;
+}
+
+- (MKMapRect) boundingMapRect
+{
+    return self.tileOverlay.boundingMapRect;
+}
+
+- (BOOL)canReplaceMapContent
+{
+    return self.tileOverlay.canReplaceMapContent;
+}
+
+@end

--- a/lib/ios/AirMaps/AIRMapLocalTile.m
+++ b/lib/ios/AirMaps/AIRMapLocalTile.m
@@ -17,7 +17,6 @@
 
 
 - (void)setPathTemplate:(NSString *)pathTemplate{
-    NSLog(@"setPathTemplate %@", pathTemplate);
     _pathTemplate = pathTemplate;
     _pathTemplateSet = YES;
     [self createTileOverlayAndRendererIfPossible];
@@ -25,7 +24,6 @@
 }
 
 - (void)setTileSize:(CGFloat)tileSize{
-    NSLog(@"setTileSize %f", tileSize);
     _tileSize = tileSize;
     _tileSizeSet = YES;
     [self createTileOverlayAndRendererIfPossible];
@@ -34,7 +32,6 @@
 
 - (void) createTileOverlayAndRendererIfPossible
 {
-    NSLog(@"createTileOverlayAndRendererIfPossible");
     if (!_pathTemplateSet || !_tileSizeSet) return;
     self.tileOverlay = [[AIRMapLocalTileOverlay alloc] initWithURLTemplate:self.pathTemplate];
     self.tileOverlay.canReplaceMapContent = YES;

--- a/lib/ios/AirMaps/AIRMapLocalTileManager.h
+++ b/lib/ios/AirMaps/AIRMapLocalTileManager.h
@@ -1,0 +1,13 @@
+//
+//  AIRMapLocalTileManager.h
+//  AirMaps
+//
+//  Created by Peter Zavadsky on 01/12/2017.
+//  Copyright © 2017 Christopher. All rights reserved.
+//
+
+#import <React/RCTViewManager.h>
+
+@interface AIRMapLocalTileManager : RCTViewManager
+
+@end

--- a/lib/ios/AirMaps/AIRMapLocalTileManager.m
+++ b/lib/ios/AirMaps/AIRMapLocalTileManager.m
@@ -1,0 +1,38 @@
+//
+//  AIRMapLocalTileManager.m
+//  AirMaps
+//
+//  Created by Peter Zavadsky on 01/12/2017.
+//  Copyright © 2017 Christopher. All rights reserved.
+//
+
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
+#import "AIRMapMarker.h"
+#import "AIRMapLocalTile.h"
+
+#import "AIRMapLocalTileManager.h"
+
+@interface AIRMapLocalTileManager()
+
+@end
+
+@implementation AIRMapLocalTileManager
+
+
+RCT_EXPORT_MODULE()
+
+- (UIView *)view
+{
+    AIRMapLocalTile *tile = [AIRMapLocalTile new];
+    return tile;
+}
+
+RCT_EXPORT_VIEW_PROPERTY(pathTemplate, NSString)
+RCT_EXPORT_VIEW_PROPERTY(tileSize, CGFloat)
+
+@end

--- a/lib/ios/AirMaps/AIRMapLocalTileOverlay.h
+++ b/lib/ios/AirMaps/AIRMapLocalTileOverlay.h
@@ -1,0 +1,12 @@
+//
+//  AIRMapLocalTileOverlay.h
+//  Pods
+//
+//  Created by Peter Zavadsky on 04/12/2017.
+//
+
+#import <MapKit/MapKit.h>
+
+@interface AIRMapLocalTileOverlay : MKTileOverlay
+
+@end

--- a/lib/ios/AirMaps/AIRMapLocalTileOverlay.m
+++ b/lib/ios/AirMaps/AIRMapLocalTileOverlay.m
@@ -1,0 +1,33 @@
+//
+//  AIRMapLocalTileOverlay.m
+//  Pods-AirMapsExplorer
+//
+//  Created by Peter Zavadsky on 04/12/2017.
+//
+
+#import "AIRMapLocalTileOverlay.h"
+
+@interface AIRMapLocalTileOverlay ()
+
+@end
+
+@implementation AIRMapLocalTileOverlay
+
+
+-(void)loadTileAtPath:(MKTileOverlayPath)path result:(void (^)(NSData *, NSError *))result {
+    NSLog(@">>>Loading tile x/y/z: %ld/%ld/%ld %@",(long)path.x,(long)path.y,(long)path.z, self.URLTemplate);
+    NSMutableString *tileFilePath = [self.URLTemplate mutableCopy];
+    [tileFilePath replaceOccurrencesOfString: @"{x}" withString:[NSString stringWithFormat:@"%i", path.x] options:NULL range:NSMakeRange(0, tileFilePath.length)];
+    [tileFilePath replaceOccurrencesOfString:@"{y}" withString:[NSString stringWithFormat:@"%i", path.y] options:NULL range:NSMakeRange(0, tileFilePath.length)];
+    [tileFilePath replaceOccurrencesOfString:@"{z}" withString:[NSString stringWithFormat:@"%i", path.z] options:NULL range:NSMakeRange(0, tileFilePath.length)];
+    NSLog(@">>>tile file path %@", tileFilePath);
+    if ([[NSFileManager defaultManager] fileExistsAtPath:tileFilePath]) {
+        NSData* tile = [NSData dataWithContentsOfFile:tileFilePath];
+        result(tile,nil);
+    } else {
+        result(nil, nil);
+    }
+}
+
+
+@end

--- a/lib/ios/AirMaps/AIRMapLocalTileOverlay.m
+++ b/lib/ios/AirMaps/AIRMapLocalTileOverlay.m
@@ -15,12 +15,10 @@
 
 
 -(void)loadTileAtPath:(MKTileOverlayPath)path result:(void (^)(NSData *, NSError *))result {
-    NSLog(@">>>Loading tile x/y/z: %ld/%ld/%ld %@",(long)path.x,(long)path.y,(long)path.z, self.URLTemplate);
     NSMutableString *tileFilePath = [self.URLTemplate mutableCopy];
     [tileFilePath replaceOccurrencesOfString: @"{x}" withString:[NSString stringWithFormat:@"%i", path.x] options:NULL range:NSMakeRange(0, tileFilePath.length)];
     [tileFilePath replaceOccurrencesOfString:@"{y}" withString:[NSString stringWithFormat:@"%i", path.y] options:NULL range:NSMakeRange(0, tileFilePath.length)];
     [tileFilePath replaceOccurrencesOfString:@"{z}" withString:[NSString stringWithFormat:@"%i", path.z] options:NULL range:NSMakeRange(0, tileFilePath.length)];
-    NSLog(@">>>tile file path %@", tileFilePath);
     if ([[NSFileManager defaultManager] fileExistsAtPath:tileFilePath]) {
         NSData* tile = [NSData dataWithContentsOfFile:tileFilePath];
         result(tile,nil);

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -23,6 +23,7 @@
 #import "AIRMapCircle.h"
 #import "SMCalloutView.h"
 #import "AIRMapUrlTile.h"
+#import "AIRMapLocalTile.h"
 #import "AIRMapSnapshot.h"
 #import "RCTConvert+AirMap.h"
 
@@ -537,6 +538,8 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
         return ((AIRMapCircle *)overlay).renderer;
     } else if ([overlay isKindOfClass:[AIRMapUrlTile class]]) {
         return ((AIRMapUrlTile *)overlay).renderer;
+    } else if ([overlay isKindOfClass:[AIRMapLocalTile class]]) {
+        return ((AIRMapLocalTile *)overlay).renderer;
     } else if([overlay isKindOfClass:[MKTileOverlay class]]) {
         return [[MKTileOverlayRenderer alloc] initWithTileOverlay:overlay];
     } else {


### PR DESCRIPTION
Added support for locally stored tile overlay similar to UrlTile component. Usage example in CustomTilesLocal.js file, but basically one just adds tile overlay within the map:
`<MapView ... >`
`<LocalTile`
`pathTemplate="/path/to/localy/stored/tiles/{z}/{x}/{y}.png"`
`tileSize={256}`
`/>`
`</MapView>`
Path just points to the path where tiles are stored.