### PR TITLE
Update for Animated.Region #24 Fix on the AnimatedMarkers Example 

### DIFF
--- a/example/examples/AnimatedMarkers.js
+++ b/example/examples/AnimatedMarkers.js
@@ -5,7 +5,6 @@ import {
   Text,
   Dimensions,
   TouchableOpacity,
-  Animated,
 } from 'react-native';
 
 import MapView from 'react-native-maps';

--- a/example/examples/AnimatedMarkers.js
+++ b/example/examples/AnimatedMarkers.js
@@ -23,7 +23,7 @@ class AnimatedMarkers extends React.Component {
     super(props);
 
     this.state = {
-      coordinate: new Animated.Region({
+      coordinate: new MapView.AnimatedRegion({
         latitude: LATITUDE,
         longitude: LONGITUDE,
       }),


### PR DESCRIPTION
Fix for 'Animated.Region undefined constructor' in recent react-native version. 
Solved by using MapView.AnimatedRegion instead of Animated.Region