### PR TITLE
corrected default value to ``round``

### DIFF
--- a/lib/components/MapPolyline.js
+++ b/lib/components/MapPolyline.js
@@ -137,6 +137,8 @@ const propTypes = {
 const defaultProps = {
   strokeColor: '#000',
   strokeWidth: 1,
+  lineJoin: 'round',
+  lineCap: 'round',
 };
 
 class MapPolyline extends React.Component {


### PR DESCRIPTION
``lineJoin`` and ``lineCap`` should have default value ``round``, according to docs.