### PR TITLE
Corrected doc text for Polyline

### DIFF
--- a/docs/polyline.md
+++ b/docs/polyline.md
@@ -7,8 +7,8 @@
 | `coordinates` | `Array<LatLng>` | (Required) | An array of coordinates to describe the polyline
 | `strokeWidth` | `Number` | `1` | The stroke width to use for the path.
 | `strokeColor` | `String` | `#000` | The stroke color to use for the path.
-| `lineCap` | `String` | `round` | The line cap style to apply to the open ends of the path.
-| `lineJoin` | `Array<LatLng>` |  | The line join style to apply to corners of the path.
+| `lineCap` | `String` | `round` | The line cap style to apply to the open ends of the path. Possible values are `butt`, `round` or `square`.
+| `lineJoin` | `String` | `round` | The line join style to apply to corners of the path. Possible values are `miter`, `round` or `bevel`.
 | `miterLimit` | `Number` |  | The limiting value that helps avoid spikes at junctions between connected line segments. The miter limit helps you avoid spikes in paths that use the `miter` `lineJoin` style. If the ratio of the miter length—that is, the diagonal length of the miter join—to the line thickness exceeds the miter limit, the joint is converted to a bevel join. The default miter limit is 10, which results in the conversion of miters whose angle at the joint is less than 11 degrees.
 | `geodesic` | `Boolean` |  | Boolean to indicate whether to draw each segment of the line as a geodesic as opposed to straight lines on the Mercator projection. A geodesic is the shortest path between two points on the Earth's surface. The geodesic curve is constructed assuming the Earth is a sphere.
 | `lineDashPhase` | `Number` | `0` | (iOS only) The offset (in points) at which to start drawing the dash pattern. Use this property to start drawing a dashed line partway through a segment or gap. For example, a phase value of 6 for the patter 5-2-3-2 would cause drawing to begin in the middle of the first gap.


### PR DESCRIPTION
The type for `lineJoin` was wrong, the default value was missing and the text for `lineJoin` and `lineCap` did not explain the possible values.