### PR TITLE
 Add openning the .xcworkspace file instead of .xcodeproj to documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,9 @@ Add to `ios/_YOUR_PROJECT_NAME_/AppDelegate.m:
 ...
 ```
 
+## Notes on running on a real ios device
 
+The steps are as described in https://facebook.github.io/react-native/docs/running-on-device.html , however instead of opening the .xcodeproj file you should open .xcworkspace file.
 
 
 ## Android


### PR DESCRIPTION
An emphasis to open .xcworkspace instead of .xcodeproj was added to documentation.