### PR TITLE
Allow initialRegion to be set when first onLayout was called, and avoid flicker

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -34,7 +34,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 @implementation AIRGoogleMap
 {
   NSMutableArray<UIView *> *_reactSubviews;
-  BOOL _initialRegionSet;
+  MKCoordinateRegion _initialRegion;
 }
 
 - (instancetype)init
@@ -46,7 +46,7 @@ id regionAsJSON(MKCoordinateRegion region) {
     _polylines = [NSMutableArray array];
     _circles = [NSMutableArray array];
     _tiles = [NSMutableArray array];
-    _initialRegionSet = false;
+    _initialRegion = MKCoordinateRegionMake(CLLocationCoordinate2DMake(0.0, 0.0), MKCoordinateSpanMake(0.0, 0.0));
   }
   return self;
 }
@@ -145,8 +145,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 #pragma clang diagnostic pop
 
 - (void)setInitialRegion:(MKCoordinateRegion)initialRegion {
-  if (_initialRegionSet) return;
-  _initialRegionSet = true;
+  _initialRegion = initialRegion;
   self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:initialRegion];
 }
 
@@ -156,7 +155,12 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 - (void)didPrepareMap {
-    if (self.onMapReady) self.onMapReady(@{});
+  if (_initialRegion.span.latitudeDelta != 0.0 &&
+      _initialRegion.span.longitudeDelta != 0.0)
+  {
+    self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:_initialRegion];
+  }
+  if (self.onMapReady) self.onMapReady(@{});
 }
 
 - (BOOL)didTapMarker:(GMSMarker *)marker {

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -144,6 +144,18 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 #pragma clang diagnostic pop
 
+- (void)didMoveToWindow
+  {
+    if (_initialRegion.span.latitudeDelta != 0.0 &&
+        _initialRegion.span.longitudeDelta != 0.0)
+    {
+      self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:_initialRegion];
+      _initialRegion = MKCoordinateRegionMake(CLLocationCoordinate2DMake(0.0, 0.0), MKCoordinateSpanMake(0.0, 0.0));
+    }
+    
+    [super didMoveToWindow];
+  }
+  
 - (void)setInitialRegion:(MKCoordinateRegion)initialRegion {
   _initialRegion = initialRegion;
   self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:initialRegion];
@@ -155,11 +167,6 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 - (void)didPrepareMap {
-  if (_initialRegion.span.latitudeDelta != 0.0 &&
-      _initialRegion.span.longitudeDelta != 0.0)
-  {
-    self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:_initialRegion];
-  }
   if (self.onMapReady) self.onMapReady(@{});
 }
 


### PR DESCRIPTION
The boolean flag that was there before failed to allow initialRegion be set at all,
as GMS has a bug where the Camera created has a zoom level of 2 - and this shows the whole world.
The Camera is only created correctly when the mapview has layout.

But then if doing this from the JS side - it causes a flicker, it first shows the whole world and then zooms in. So I've replace the boolean flag with storage of the initial region to be set automatically when the view is added to the window.
  