### PR TITLE
 Allow wider range of react and react-native versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "mapkit"
   ],
   "peerDependencies": {
-    "react": "16.0.0",
-    "react-native": "0.51.0",
+    "react": "^16.0.0",
+    "react-native": ">=0.51.0",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm upgrading my project to react-native@0.52, I've got some peerDeps errors, so I thought I'd drop by and toss in a patch.

If you'd rather have `^0.51.0 || ^0.52.0`, I can do that too.

I did notice: The README states that the peerDep for react-native should be "*"…

> […] the peer dependency of this requirement is set to "react-native": "*" explicitly for this reason.

Would you like me to edit that paragraph as well?

The change from `>=` to `^0.51` seems to have happened in https://github.com/react-community/react-native-maps/pull/1879, fwiw.

Have a great week!