### PR TITLE
Replace CommonJS exports with ES6 exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ versions you should add `react` as a dependency in your `package.json`.
 
 [`<MapView />` Component API](docs/mapview.md)
 
-[`<MapView.Marker />` Component API](docs/marker.md)
+[`<Marker />` Component API](docs/marker.md)
 
-[`<MapView.Callout />` Component API](docs/callout.md)
+[`<Callout />` Component API](docs/callout.md)
 
-[`<MapView.Polygon />` Component API](docs/polygon.md)
+[`<Polygon />` Component API](docs/polygon.md)
 
-[`<MapView.Polyline />` Component API](docs/polyline.md)
+[`<Polyline />` Component API](docs/polyline.md)
 
-[`<MapView.Circle />` Component API](docs/circle.md)
+[`<Circle />` Component API](docs/circle.md)
 
-[`<MapView.Overlay />` Component API](docs/overlay.md)
+[`<Overlay />` Component API](docs/overlay.md)
 
 ## General Usage
 
@@ -98,12 +98,14 @@ render() {
 ### Rendering a list of markers on a map
 
 ```jsx
+import { Marker } from 'react-native-maps';
+
 <MapView
   region={this.state.region}
   onRegionChange={this.onRegionChange}
 >
   {this.state.markers.map(marker => (
-    <MapView.Marker
+    <Marker
       coordinate={marker.latlng}
       title={marker.title}
       description={marker.description}
@@ -115,15 +117,15 @@ render() {
 ### Rendering a Marker with a custom view
 
 ```jsx
-<MapView.Marker coordinate={marker.latlng}>
+<Marker coordinate={marker.latlng}>
   <MyCustomMarkerView {...marker} />
-</MapView.Marker>
+</Marker>
 ```
 
 ### Rendering a Marker with a custom image
 
 ```jsx
-<MapView.Marker
+<Marker
   coordinate={marker.latlng}
   image={require('../assets/pin.png')}
 />
@@ -132,19 +134,21 @@ render() {
 ### Rendering a custom Marker with a custom Callout
 
 ```jsx
-<MapView.Marker coordinate={marker.latlng}>
+import { Callout } from 'react-native-maps';
+
+<Marker coordinate={marker.latlng}>
   <MyCustomMarkerView {...marker} />
-  <MapView.Callout>
+  <Callout>
     <MyCustomCalloutView {...marker} />
-  </MapView.Callout>
-</MapView.Marker>
+  </Callout>
+</Marker>
 ```
 
 ### Draggable Markers
 
 ```jsx
 <MapView initialRegion={...}>
-  <MapView.Marker draggable
+  <Marker draggable
     coordinate={this.state.x}
     onDragEnd={(e) => this.setState({ x: e.nativeEvent.coordinate })}
   />
@@ -156,11 +160,13 @@ render() {
 #### Tile Overlay using tile server
 
 ```jsx
+import { UrlTile } from 'react-native-maps';
+
 <MapView
   region={this.state.region}
   onRegionChange={this.onRegionChange}
 >
-  <MapView.UrlTile
+  <UrlTile
    /**
    * The url template of the tile server. The patterns {x} {y} {z} will be replaced at runtime
    * For example, http://c.tile.openstreetmap.org/{z}/{x}/{y}.png
@@ -181,11 +187,13 @@ For IOS: configure [App Transport Security](https://developer.apple.com/library/
 Tiles can be stored locally within device using xyz tiling scheme and displayed as tile overlay as well. This is usefull especially for offline map usage when tiles are available for selected map region within device storage.
 
 ```jsx
+import { LocalTile } from 'react-native-maps';
+
 <MapView
   region={this.state.region}
   onRegionChange={this.onRegionChange}
 >
-  <MapView.LocalTile
+  <LocalTile
    /**
     * The path template of the locally stored tiles. The patterns {x} {y} {z} will be replaced at runtime
     * For example, /storage/emulated/0/mytiles/{z}/{x}/{y}.png
@@ -386,14 +394,14 @@ Enable lite mode on Android with `liteMode` prop. Ideal when having multiple map
 
 ### Animated Region
 
-The MapView can accept an `MapView.AnimatedRegion` value as its `region` prop. This allows you to utilize the Animated API to control the map's center and zoom.
+The MapView can accept an `AnimatedRegion` value as its `region` prop. This allows you to utilize the Animated API to control the map's center and zoom.
 
 ```jsx
-import MapView from 'react-native-maps';
+import MapView, { AnimatedRegion, Animated } from 'react-native-maps';
 
 getInitialState() {
   return {
-    region: new MapView.AnimatedRegion({
+    region: new AnimatedRegion({
       latitude: LATITUDE,
       longitude: LONGITUDE,
       latitudeDelta: LATITUDE_DELTA,
@@ -408,7 +416,7 @@ onRegionChange(region) {
 
 render() {
   return (
-    <MapView.Animated
+    <Animated
       region={this.state.region}
       onRegionChange={this.onRegionChange}
     />
@@ -421,9 +429,11 @@ render() {
 Markers can also accept an `AnimatedRegion` value as a coordinate.
 
 ```jsx
+import Mapview, { AnimatedRegion, Marker } from 'react-native-maps';
+
 getInitialState() {
   return {
-    coordinate: new MapView.AnimatedRegion({
+    coordinate: new AnimatedRegion({
       latitude: LATITUDE,
       longitude: LONGITUDE,
     }),
@@ -442,7 +452,7 @@ componentWillReceiveProps(nextProps) {
 render() {
   return (
     <MapView initialRegion={...}>
-      <MapView.Marker.Animated coordinate={this.state.coordinate} />
+      <Marker.Animated coordinate={this.state.coordinate} />
     </MapView>
   );
 }
@@ -451,6 +461,8 @@ render() {
 ### Take Snapshot of map
 
 ```jsx
+import MapView, { Marker } from 'react-native-maps';
+
 getInitialState() {
   return {
     coordinate: {
@@ -480,7 +492,7 @@ render() {
   return (
     <View>
       <MapView initialRegion={...} ref={map => { this.map = map }}>
-        <MapView.Marker coordinate={this.state.coordinate} />
+        <Marker coordinate={this.state.coordinate} />
       </MapView>
       <Image source={{ uri: this.state.mapSnapshot.uri }} />
       <TouchableOpacity onPress={this.takeSnapshot}>

--- a/docs/callout.md
+++ b/docs/callout.md
@@ -1,4 +1,4 @@
-# `<MapView.Callout />` Component API
+# `<Callout />` Component API
 
 ## Props
 

--- a/docs/circle.md
+++ b/docs/circle.md
@@ -1,4 +1,4 @@
-# `<MapView.Circle />` Component API
+# `<Circle />` Component API
 
 ## Props
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -214,7 +214,7 @@ If you use Xcode with version less than 9 you may get `use of undeclared identif
      },
    });
 
-   module.exports = class MyApp extends React.Component {
+   export default class MyApp extends React.Component {
      render() {
        const { region } = this.props;
        console.log(region);

--- a/docs/marker.md
+++ b/docs/marker.md
@@ -1,11 +1,11 @@
-# `<MapView.Marker />` Component API
+# `<Marker />` Component API
 
 ## Props
 
 | Prop | Type | Default | Note |
 |---|---|---|---|
-| `title` | `String` |  | The title of the marker. This is only used if the <Marker /> component has no children that are an `<MapView.Callout />`, in which case the default callout behavior will be used, which will show both the `title` and the `description`, if provided.
-| `description` | `String` |  | The description of the marker. This is only used if the <Marker /> component has no children that are an `<MapView.Callout />`, in which case the default callout behavior will be used, which will show both the `title` and the `description`, if provided.
+| `title` | `String` |  | The title of the marker. This is only used if the <Marker /> component has no children that are a `<Callout />`, in which case the default callout behavior will be used, which will show both the `title` and the `description`, if provided.
+| `description` | `String` |  | The description of the marker. This is only used if the <Marker /> component has no children that are a `<Callout />`, in which case the default callout behavior will be used, which will show both the `title` and the `description`, if provided.
 | `image` | `ImageSource` |  | A custom image to be used as the marker's icon. Only local image resources are allowed to be used.
 | `pinColor` | `Color` |  | If no custom marker view or custom image is provided, the platform default pin will be used, which can be customized by this color. Ignored if a custom marker is being used.
 | `coordinate` | `LatLng` |  | The coordinate for the marker.

--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -1,4 +1,4 @@
-# `<MapView.Overlay />` Component API
+# `<Overlay />` Component API
 
 ## Props
 

--- a/docs/polygon.md
+++ b/docs/polygon.md
@@ -1,4 +1,4 @@
-# `<MapView.Polygon />` Component API
+# `<Polygon />` Component API
 
 ## Props
 

--- a/docs/polyline.md
+++ b/docs/polyline.md
@@ -1,4 +1,4 @@
-# `<MapView.Polyline />` Component API
+# `<Polyline />` Component API
 
 ## Props
 
@@ -37,8 +37,10 @@ Gradient polylines can be created by using the `strokeColors` prop. `strokeColor
 Example:
 
 ```js
+import MapView, { Polyline } from 'react-native-maps';
+
 <MapView>
-	<MapView.Polyline
+	<Polyline
 		coordinates={[
 			{ latitude: 37.8025259, longitude: -122.4351431 },
 			{ latitude: 37.7896386, longitude: -122.421646 },

--- a/example/App.js
+++ b/example/App.js
@@ -191,4 +191,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = App;
+export default App;

--- a/example/examples/AnimatedMarkers.js
+++ b/example/examples/AnimatedMarkers.js
@@ -104,4 +104,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = AnimatedMarkers;
+export default AnimatedMarkers;

--- a/example/examples/AnimatedMarkers.js
+++ b/example/examples/AnimatedMarkers.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { ProviderPropType, Marker, AnimatedRegion } from 'react-native-maps';
 
 const screen = Dimensions.get('window');
 
@@ -22,7 +22,7 @@ class AnimatedMarkers extends React.Component {
     super(props);
 
     this.state = {
-      coordinate: new MapView.AnimatedRegion({
+      coordinate: new AnimatedRegion({
         latitude: LATITUDE,
         longitude: LONGITUDE,
       }),
@@ -50,7 +50,7 @@ class AnimatedMarkers extends React.Component {
             longitudeDelta: LONGITUDE_DELTA,
           }}
         >
-          <MapView.Marker.Animated
+          <Marker.Animated
             coordinate={this.state.coordinate}
           />
         </MapView>
@@ -68,7 +68,7 @@ class AnimatedMarkers extends React.Component {
 }
 
 AnimatedMarkers.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/AnimatedPriceMarker.js
+++ b/example/examples/AnimatedPriceMarker.js
@@ -105,4 +105,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = AnimatedPriceMarker;
+export default AnimatedPriceMarker;

--- a/example/examples/AnimatedViews.js
+++ b/example/examples/AnimatedViews.js
@@ -418,4 +418,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = AnimatedViews;
+export default AnimatedViews;

--- a/example/examples/AnimatedViews.js
+++ b/example/examples/AnimatedViews.js
@@ -6,7 +6,12 @@ import {
   Animated,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import {
+  ProviderPropType,
+  Animated as AnimatedMap,
+  AnimatedRegion,
+  Marker,
+} from 'react-native-maps';
 import PanController from './PanController';
 import PriceMarker from './AnimatedPriceMarker';
 
@@ -191,7 +196,7 @@ class AnimatedViews extends React.Component {
       scale,
       translateY,
       markers,
-      region: new MapView.AnimatedRegion({
+      region: new AnimatedRegion({
         latitude: LATITUDE,
         longitude: LONGITUDE,
         latitudeDelta: LATITUDE_DELTA,
@@ -324,7 +329,7 @@ class AnimatedViews extends React.Component {
           onStartShouldSetPanResponder={this.onStartShouldSetPanResponder}
           onMoveShouldSetPanResponder={this.onMoveShouldSetPanResponder}
         >
-          <MapView.Animated
+          <AnimatedMap
             provider={this.props.provider}
             style={styles.map}
             region={region}
@@ -338,7 +343,7 @@ class AnimatedViews extends React.Component {
               } = animations[i];
 
               return (
-                <MapView.Marker
+                <Marker
                   key={marker.id}
                   coordinate={marker.coordinate}
                 >
@@ -352,10 +357,10 @@ class AnimatedViews extends React.Component {
                     amount={marker.amount}
                     selected={selected}
                   />
-                </MapView.Marker>
+                </Marker>
               );
             })}
-          </MapView.Animated>
+          </AnimatedMap>
           <View style={styles.itemContainer}>
             {markers.map((marker, i) => {
               const {
@@ -387,7 +392,7 @@ class AnimatedViews extends React.Component {
 }
 
 AnimatedViews.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/BugMarkerWontUpdate.js
+++ b/example/examples/BugMarkerWontUpdate.js
@@ -6,7 +6,7 @@ import {
   Dimensions,
   TouchableOpacity,
 } from 'react-native';
-import MapView from 'react-native-maps';
+import MapView, { ProviderPropType } from 'react-native-maps';
 import MyLocationMapMarker from './MyLocationMapMarker';
 
 const { width, height } = Dimensions.get('window');
@@ -93,7 +93,7 @@ class BugMarkerWontUpdate extends React.Component {
 }
 
 BugMarkerWontUpdate.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/BugMarkerWontUpdate.js
+++ b/example/examples/BugMarkerWontUpdate.js
@@ -131,4 +131,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = BugMarkerWontUpdate;
+export default BugMarkerWontUpdate;

--- a/example/examples/CachedMap.js
+++ b/example/examples/CachedMap.js
@@ -1832,4 +1832,4 @@ const COUNTRIES = [
   },
 ];
 
-module.exports = CachedMap;
+export default CachedMap;

--- a/example/examples/CachedMap.js
+++ b/example/examples/CachedMap.js
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { ProviderPropType, Marker } from 'react-native-maps';
 import flagImg from './assets/flag-blue.png';
 
 const HORIZONTAL_PADDING = 12;
@@ -69,7 +69,7 @@ class CachedMap extends React.Component {
                 loadingIndicatorColor="#666666"
                 loadingBackgroundColor="#eeeeee"
               >
-                <MapView.Marker
+                <Marker
                   coordinate={region}
                   centerOffset={{ x: -18, y: -60 }}
                   anchor={{ x: 0.69, y: 1 }}
@@ -86,7 +86,7 @@ class CachedMap extends React.Component {
 }
 
 CachedMap.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/Callouts.js
+++ b/example/examples/Callouts.js
@@ -159,4 +159,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = Callouts;
+export default Callouts;

--- a/example/examples/Callouts.js
+++ b/example/examples/Callouts.js
@@ -6,7 +6,7 @@ import {
   Dimensions,
   TouchableOpacity,
 } from 'react-native';
-import MapView from 'react-native-maps';
+import MapView, { Marker, Callout, ProviderPropType } from 'react-native-maps';
 import CustomCallout from './CustomCallout';
 
 const { width, height } = Dimensions.get('window');
@@ -69,33 +69,33 @@ class Callouts extends React.Component {
           style={styles.map}
           initialRegion={region}
         >
-          <MapView.Marker
+          <Marker
             ref={ref => { this.marker1 = ref; }}
             coordinate={markers[0].coordinate}
             title="This is a native view"
             description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation" // eslint-disable-line max-len
           />
-          <MapView.Marker
+          <Marker
             coordinate={markers[1].coordinate}
           >
-            <MapView.Callout style={styles.plainView}>
+            <Callout style={styles.plainView}>
 
               <View>
                 <Text>This is a plain view</Text>
               </View>
-            </MapView.Callout>
-          </MapView.Marker>
-          <MapView.Marker
+            </Callout>
+          </Marker>
+          <Marker
             coordinate={markers[2].coordinate}
             calloutOffset={{ x: -8, y: 28 }}
             calloutAnchor={{ x: 0.5, y: 0.4 }}
           >
-            <MapView.Callout tooltip style={styles.customView}>
+            <Callout tooltip style={styles.customView}>
               <CustomCallout>
                 <Text>This is a custom callout bubble view</Text>
               </CustomCallout>
-            </MapView.Callout>
-          </MapView.Marker>
+            </Callout>
+          </Marker>
         </MapView>
         <View style={styles.buttonContainer}>
           <View style={styles.bubble}>
@@ -116,7 +116,7 @@ class Callouts extends React.Component {
 }
 
 Callouts.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/CustomCallout.js
+++ b/example/examples/CustomCallout.js
@@ -66,4 +66,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = CustomCallout;
+export default CustomCallout;

--- a/example/examples/CustomMarkers.js
+++ b/example/examples/CustomMarkers.js
@@ -115,4 +115,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = CustomMarkers;
+export default CustomMarkers;

--- a/example/examples/CustomMarkers.js
+++ b/example/examples/CustomMarkers.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 import flagPinkImg from './assets/flag-pink.png';
 
 const { width, height } = Dimensions.get('window');
@@ -58,7 +58,7 @@ class CustomMarkers extends React.Component {
           onPress={this.onMapPress}
         >
           {this.state.markers.map(marker => (
-            <MapView.Marker
+            <Marker
               title={marker.key}
               image={flagPinkImg}
               key={marker.key}
@@ -80,7 +80,7 @@ class CustomMarkers extends React.Component {
 }
 
 CustomMarkers.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/CustomOverlay.js
+++ b/example/examples/CustomOverlay.js
@@ -82,4 +82,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = CustomOverlay;
+export default CustomOverlay;

--- a/example/examples/CustomOverlay.js
+++ b/example/examples/CustomOverlay.js
@@ -5,7 +5,7 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { ProviderPropType } from 'react-native-maps';
 import XMarksTheSpot from './CustomOverlayXMarksTheSpot';
 
 const { width, height } = Dimensions.get('window');
@@ -68,7 +68,7 @@ class CustomOverlay extends React.Component {
 }
 
 CustomOverlay.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/CustomOverlayXMarksTheSpot.js
+++ b/example/examples/CustomOverlayXMarksTheSpot.js
@@ -2,24 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { View } from 'react-native';
-import MapView from 'react-native-maps';
+import { Polygon, Polyline, Marker } from 'react-native-maps';
 
 class XMarksTheSpot extends React.Component {
   render() {
     return (
       <View>
-        <MapView.Polygon
+        <Polygon
           coordinates={this.props.coordinates}
           strokeColor="rgba(0, 0, 0, 1)"
           strokeWidth={3}
         />
-        <MapView.Polyline
+        <Polyline
           coordinates={[this.props.coordinates[0], this.props.coordinates[2]]}
         />
-        <MapView.Polyline
+        <Polyline
           coordinates={[this.props.coordinates[1], this.props.coordinates[3]]}
         />
-        <MapView.Marker
+        <Marker
           coordinate={this.props.center}
         />
       </View>

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -6,7 +6,7 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView, { MAP_TYPES, PROVIDER_DEFAULT } from 'react-native-maps';
+import MapView, { MAP_TYPES, PROVIDER_DEFAULT, ProviderPropType, UrlTile } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -46,7 +46,7 @@ class CustomTiles extends React.Component {
           style={styles.map}
           initialRegion={region}
         >
-          <MapView.UrlTile
+          <UrlTile
             urlTemplate="http://c.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg"
             zIndex={-1}
           />
@@ -62,7 +62,7 @@ class CustomTiles extends React.Component {
 }
 
 CustomTiles.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -106,4 +106,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = CustomTiles;
+export default CustomTiles;

--- a/example/examples/CustomTilesLocal.js
+++ b/example/examples/CustomTilesLocal.js
@@ -107,4 +107,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = CustomTiles;
+export default CustomTiles;

--- a/example/examples/CustomTilesLocal.js
+++ b/example/examples/CustomTilesLocal.js
@@ -6,7 +6,12 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView, { MAP_TYPES, PROVIDER_DEFAULT } from 'react-native-maps';
+import MapView, {
+  MAP_TYPES,
+  PROVIDER_DEFAULT,
+  LocalTile,
+  ProviderPropType,
+} from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -46,7 +51,7 @@ class CustomTiles extends React.Component {
           style={styles.map}
           initialRegion={region}
         >
-          <MapView.LocalTile
+          <LocalTile
             pathTemplate="/path/to/locally/saved/tiles/{z}/{x}/{y}.png"
             tileSize={256}
             zIndex={-1}
@@ -63,7 +68,7 @@ class CustomTiles extends React.Component {
 }
 
 CustomTiles.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/DefaultMarkers.js
+++ b/example/examples/DefaultMarkers.js
@@ -116,4 +116,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = DefaultMarkers;
+export default DefaultMarkers;

--- a/example/examples/DefaultMarkers.js
+++ b/example/examples/DefaultMarkers.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -60,7 +60,7 @@ class DefaultMarkers extends React.Component {
           onPress={(e) => this.onMapPress(e)}
         >
           {this.state.markers.map(marker => (
-            <MapView.Marker
+            <Marker
               key={marker.key}
               coordinate={marker.coordinate}
               pinColor={marker.color}
@@ -81,7 +81,7 @@ class DefaultMarkers extends React.Component {
 }
 
 DefaultMarkers.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/DisplayLatLng.js
+++ b/example/examples/DisplayLatLng.js
@@ -168,4 +168,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = DisplayLatLng;
+export default DisplayLatLng;

--- a/example/examples/DisplayLatLng.js
+++ b/example/examples/DisplayLatLng.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-import MapView, { MAP_TYPES } from 'react-native-maps';
+import MapView, { MAP_TYPES, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -129,7 +129,7 @@ class DisplayLatLng extends React.Component {
 }
 
 DisplayLatLng.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/DraggableMarkers.js
+++ b/example/examples/DraggableMarkers.js
@@ -91,4 +91,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = MarkerTypes;
+export default MarkerTypes;

--- a/example/examples/DraggableMarkers.js
+++ b/example/examples/DraggableMarkers.js
@@ -5,7 +5,7 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 import PriceMarker from './PriceMarker';
 
 const { width, height } = Dimensions.get('window');
@@ -50,7 +50,7 @@ class MarkerTypes extends React.Component {
             longitudeDelta: LONGITUDE_DELTA,
           }}
         >
-          <MapView.Marker
+          <Marker
             coordinate={this.state.a}
             onSelect={(e) => log('onSelect', e)}
             onDrag={(e) => log('onDrag', e)}
@@ -60,8 +60,8 @@ class MarkerTypes extends React.Component {
             draggable
           >
             <PriceMarker amount={99} />
-          </MapView.Marker>
-          <MapView.Marker
+          </Marker>
+          <Marker
             coordinate={this.state.b}
             onSelect={(e) => log('onSelect', e)}
             onDrag={(e) => log('onDrag', e)}
@@ -77,7 +77,7 @@ class MarkerTypes extends React.Component {
 }
 
 MarkerTypes.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/EventListener.js
+++ b/example/examples/EventListener.js
@@ -9,7 +9,7 @@ import {
   ScrollView,
 } from 'react-native';
 // eslint-disable-next-line max-len
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType, Polygon, Polyline, Callout } from 'react-native-maps';
 import PriceMarker from './PriceMarker';
 
 const { width, height } = Dimensions.get('window');
@@ -94,19 +94,19 @@ class EventListener extends React.Component {
           onMarkerDeselect={this.recordEvent('Map::onMarkerDeselect')}
           onCalloutPress={this.recordEvent('Map::onCalloutPress')}
         >
-          <MapView.Marker
+          <Marker
             coordinate={{
               latitude: LATITUDE + (LATITUDE_DELTA / 2),
               longitude: LONGITUDE + (LONGITUDE_DELTA / 2),
             }}
           />
-          <MapView.Marker
+          <Marker
             coordinate={{
               latitude: LATITUDE - (LATITUDE_DELTA / 2),
               longitude: LONGITUDE - (LONGITUDE_DELTA / 2),
             }}
           />
-          <MapView.Marker
+          <Marker
             title="This is a title"
             description="This is a description"
             coordinate={this.state.region}
@@ -116,16 +116,16 @@ class EventListener extends React.Component {
             onCalloutPress={this.recordEvent('Marker::onCalloutPress')}
           >
             <PriceMarker amount={99} />
-            <MapView.Callout
+            <Callout
               style={styles.callout}
               onPress={this.recordEvent('Callout::onPress')}
             >
               <View>
                 <Text>Well hello there...</Text>
               </View>
-            </MapView.Callout>
-          </MapView.Marker>
-          <MapView.Polygon
+            </Callout>
+          </Marker>
+          <Polygon
             fillColor={'rgba(255,0,0,0.3)'}
             onPress={this.recordEvent('Polygon::onPress')}
             tappable
@@ -140,7 +140,7 @@ class EventListener extends React.Component {
               longitude: LONGITUDE + (LONGITUDE_DELTA / 2),
             }]}
           />
-          <MapView.Polyline
+          <Polyline
             strokeColor={'rgba(255,0,0,1)'}
             onPress={this.recordEvent('Polyline::onPress')}
             tappable
@@ -167,7 +167,7 @@ class EventListener extends React.Component {
 }
 
 EventListener.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/EventListener.js
+++ b/example/examples/EventListener.js
@@ -231,4 +231,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = EventListener;
+export default EventListener;

--- a/example/examples/EventListener.js
+++ b/example/examples/EventListener.js
@@ -68,6 +68,9 @@ class EventListener extends React.Component {
 
   recordEvent(name) {
     return e => {
+      if (e.persist) {
+        e.persist();  // Avoids warnings relating to https://fb.me/react-event-pooling
+      }
       this.setState(prevState => ({
         events: [
           this.makeEvent(e, name),

--- a/example/examples/FitToCoordinates.js
+++ b/example/examples/FitToCoordinates.js
@@ -7,7 +7,7 @@ import {
   Text,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -70,7 +70,7 @@ class FitToCoordinates extends React.Component {
           }}
         >
           {MARKERS.map((marker, i) => (
-            <MapView.Marker
+            <Marker
               key={i}
               coordinate={marker}
             />

--- a/example/examples/FitToCoordinates.js
+++ b/example/examples/FitToCoordinates.js
@@ -129,4 +129,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = FitToCoordinates;
+export default FitToCoordinates;

--- a/example/examples/FitToSuppliedMarkers.js
+++ b/example/examples/FitToSuppliedMarkers.js
@@ -5,7 +5,7 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -123,23 +123,23 @@ class FocusOnMarkers extends React.Component {
             longitudeDelta: LONGITUDE_DELTA,
           }}
         >
-          <MapView.Marker
+          <Marker
             identifier="Marker1"
             coordinate={this.state.a}
           />
-          <MapView.Marker
+          <Marker
             identifier="Marker2"
             coordinate={this.state.b}
           />
-          <MapView.Marker
+          <Marker
             identifier="Marker3"
             coordinate={this.state.c}
           />
-          <MapView.Marker
+          <Marker
             identifier="Marker4"
             coordinate={this.state.d}
           />
-          <MapView.Marker
+          <Marker
             identifier="Marker5"
             coordinate={this.state.e}
           />
@@ -150,7 +150,7 @@ class FocusOnMarkers extends React.Component {
 }
 
 FocusOnMarkers.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/FitToSuppliedMarkers.js
+++ b/example/examples/FitToSuppliedMarkers.js
@@ -164,4 +164,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = FocusOnMarkers;
+export default FocusOnMarkers;

--- a/example/examples/GradientPolylines.js
+++ b/example/examples/GradientPolylines.js
@@ -4,7 +4,7 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Polyline, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -53,7 +53,7 @@ class GradientPolylines extends React.Component {
         style={styles.container}
         initialRegion={this.state.region}
       >
-        <MapView.Polyline
+        <Polyline
           coordinates={COORDINATES}
           strokeColor="#000"
           strokeColors={COLORS}
@@ -65,7 +65,7 @@ class GradientPolylines extends React.Component {
 }
 
 GradientPolylines.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/GradientPolylines.js
+++ b/example/examples/GradientPolylines.js
@@ -74,4 +74,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = GradientPolylines;
+export default GradientPolylines;

--- a/example/examples/LegalLabel.js
+++ b/example/examples/LegalLabel.js
@@ -8,13 +8,13 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 
 const screen = Dimensions.get('window');
 
 class LegalLabel extends React.Component {
   static propTypes = {
-    provider: MapView.ProviderPropType,
+    provider: ProviderPropType,
   }
 
   state = {
@@ -67,7 +67,7 @@ class LegalLabel extends React.Component {
             longitudeDelta: LONGITUDE_DELTA,
           }}
         >
-          <MapView.Marker coordinate={latlng} />
+          <Marker coordinate={latlng} />
         </MapView>
 
         <View style={styles.username}>

--- a/example/examples/LegalLabel.js
+++ b/example/examples/LegalLabel.js
@@ -144,4 +144,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = LegalLabel;
+export default LegalLabel;

--- a/example/examples/LiteMapView.js
+++ b/example/examples/LiteMapView.js
@@ -50,4 +50,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = LiteMapView;
+export default LiteMapView;

--- a/example/examples/LoadingMap.js
+++ b/example/examples/LoadingMap.js
@@ -6,7 +6,7 @@ import {
   StyleSheet,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker, Callout, ProviderPropType } from 'react-native-maps';
 import flagImg from './assets/flag-blue.png';
 
 const { width, height } = Dimensions.get('window');
@@ -44,7 +44,7 @@ class LoadingMap extends React.Component {
           loadingIndicatorColor="#666666"
           loadingBackgroundColor="#eeeeee"
         >
-          <MapView.Marker
+          <Marker
             coordinate={{
               latitude: LATITUDE + SPACE,
               longitude: LONGITUDE + SPACE,
@@ -53,7 +53,7 @@ class LoadingMap extends React.Component {
             anchor={{ x: 0.69, y: 1 }}
             image={flagImg}
           />
-          <MapView.Marker
+          <Marker
             coordinate={{
               latitude: LATITUDE - SPACE,
               longitude: LONGITUDE - SPACE,
@@ -61,12 +61,12 @@ class LoadingMap extends React.Component {
             centerOffset={{ x: -42, y: -60 }}
             anchor={{ x: 0.84, y: 1 }}
           >
-            <MapView.Callout>
+            <Callout>
               <View>
                 <Text>This is a plain view</Text>
               </View>
-            </MapView.Callout>
-          </MapView.Marker>
+            </Callout>
+          </Marker>
         </MapView>
         <View style={styles.buttonContainer}>
           <View style={styles.bubble}>
@@ -79,7 +79,7 @@ class LoadingMap extends React.Component {
 }
 
 LoadingMap.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/LoadingMap.js
+++ b/example/examples/LoadingMap.js
@@ -104,4 +104,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = LoadingMap;
+export default LoadingMap;

--- a/example/examples/MapStyle.js
+++ b/example/examples/MapStyle.js
@@ -219,4 +219,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = MapStyle;
+export default MapStyle;

--- a/example/examples/MapStyle.js
+++ b/example/examples/MapStyle.js
@@ -5,7 +5,7 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -205,7 +205,7 @@ class MapStyle extends React.Component {
 }
 
 MapStyle.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/MarkerTypes.js
+++ b/example/examples/MarkerTypes.js
@@ -5,7 +5,7 @@ import {
   Text,
   Dimensions,
 } from 'react-native';
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 import flagBlueImg from './assets/flag-blue.png';
 import flagPinkImg from './assets/flag-pink.png';
 
@@ -40,7 +40,7 @@ class MarkerTypes extends React.Component {
             longitudeDelta: LONGITUDE_DELTA,
           }}
         >
-          <MapView.Marker
+          <Marker
             onPress={() => this.setState({ marker1: !this.state.marker1 })}
             coordinate={{
               latitude: LATITUDE + SPACE,
@@ -51,8 +51,8 @@ class MarkerTypes extends React.Component {
             image={this.state.marker1 ? flagBlueImg : flagPinkImg}
           >
             <Text style={styles.marker}>X</Text>
-          </MapView.Marker>
-          <MapView.Marker
+          </Marker>
+          <Marker
             onPress={() => this.setState({ marker2: !this.state.marker2 })}
             coordinate={{
               latitude: LATITUDE - SPACE,
@@ -62,7 +62,7 @@ class MarkerTypes extends React.Component {
             anchor={{ x: 0.84, y: 1 }}
             image={this.state.marker2 ? flagBlueImg : flagPinkImg}
           />
-          <MapView.Marker
+          <Marker
             onPress={() => this.setState({ marker2: !this.state.marker2 })}
             coordinate={{
               latitude: LATITUDE + SPACE,
@@ -80,7 +80,7 @@ class MarkerTypes extends React.Component {
 }
 
 MarkerTypes.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/MarkerTypes.js
+++ b/example/examples/MarkerTypes.js
@@ -99,4 +99,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = MarkerTypes;
+export default MarkerTypes;

--- a/example/examples/MyLocationMapMarker.js
+++ b/example/examples/MyLocationMapMarker.js
@@ -8,7 +8,7 @@ import {
   PermissionsAndroid,
   Platform,
 } from 'react-native';
-import MapView from 'react-native-maps';
+import { Marker } from 'react-native-maps';
 import isEqual from 'lodash/isEqual';
 
 const GEOLOCATION_OPTIONS = { enableHighAccuracy: true, timeout: 20000, maximumAge: 1000 };
@@ -17,7 +17,7 @@ const ANCHOR = { x: 0.5, y: 0.5 };
 const colorOfmyLocationMapMarker = 'blue';
 
 const propTypes = {
-  ...MapView.Marker.propTypes,
+  ...Marker.propTypes,
   // override this prop to make it optional
   coordinate: PropTypes.shape({
     latitude: PropTypes.number.isRequired,
@@ -87,7 +87,7 @@ export default class MyLocationMapMarker extends React.PureComponent {
     const rotate = (typeof heading === 'number' && heading >= 0) ? `${heading}deg` : null;
 
     return (
-      <MapView.Marker
+      <Marker
         anchor={ANCHOR}
         style={styles.mapMarker}
         {...this.props}
@@ -107,7 +107,7 @@ export default class MyLocationMapMarker extends React.PureComponent {
           </View>
         </View>
         {this.props.children}
-      </MapView.Marker>
+      </Marker>
     );
   }
 }

--- a/example/examples/Overlays.js
+++ b/example/examples/Overlays.js
@@ -6,7 +6,7 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Circle, Polygon, Polyline, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -79,7 +79,7 @@ class Overlays extends React.Component {
           style={styles.map}
           initialRegion={region}
         >
-          <MapView.Circle
+          <Circle
             center={circle.center}
             radius={circle.radius}
             fillColor="rgba(255, 255, 255, 1)"
@@ -87,13 +87,13 @@ class Overlays extends React.Component {
             zIndex={2}
             strokeWidth={2}
           />
-          <MapView.Polygon
+          <Polygon
             coordinates={polygon}
             fillColor="rgba(0, 200, 0, 0.5)"
             strokeColor="rgba(0,0,0,0.5)"
             strokeWidth={2}
           />
-          <MapView.Polyline
+          <Polyline
             coordinates={polyline}
             strokeColor="rgba(0,0,200,0.5)"
             strokeWidth={3}
@@ -111,7 +111,7 @@ class Overlays extends React.Component {
 }
 
 Overlays.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/Overlays.js
+++ b/example/examples/Overlays.js
@@ -147,4 +147,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = Overlays;
+export default Overlays;

--- a/example/examples/PanController.js
+++ b/example/examples/PanController.js
@@ -413,4 +413,4 @@ class PanController extends React.Component{
   }
 };
 
-module.exports = PanController;
+export default PanController;

--- a/example/examples/PolygonCreator.js
+++ b/example/examples/PolygonCreator.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { MAP_TYPES, Polygon, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -126,13 +126,13 @@ class PolygonCreator extends React.Component {
         <MapView
           provider={this.props.provider}
           style={styles.map}
-          mapType={MapView.MAP_TYPES.HYBRID}
+          mapType={MAP_TYPES.HYBRID}
           initialRegion={this.state.region}
           onPress={e => this.onPress(e)}
           {...mapOptions}
         >
           {this.state.polygons.map(polygon => (
-            <MapView.Polygon
+            <Polygon
               key={polygon.id}
               coordinates={polygon.coordinates}
               holes={polygon.holes}
@@ -142,7 +142,7 @@ class PolygonCreator extends React.Component {
             />
           ))}
           {this.state.editing && (
-            <MapView.Polygon
+            <Polygon
               key={this.state.editing.id}
               coordinates={this.state.editing.coordinates}
               holes={this.state.editing.holes}
@@ -176,7 +176,7 @@ class PolygonCreator extends React.Component {
 }
 
 PolygonCreator.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/PolygonCreator.js
+++ b/example/examples/PolygonCreator.js
@@ -211,4 +211,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = PolygonCreator;
+export default PolygonCreator;

--- a/example/examples/PolylineCreator.js
+++ b/example/examples/PolylineCreator.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Polyline, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -75,7 +75,7 @@ class PolylineCreator extends React.Component {
           onPanDrag={e => this.onPanDrag(e)}
         >
           {this.state.polylines.map(polyline => (
-            <MapView.Polyline
+            <Polyline
               key={polyline.id}
               coordinates={polyline.coordinates}
               strokeColor="#000"
@@ -84,7 +84,7 @@ class PolylineCreator extends React.Component {
             />
           ))}
           {this.state.editing &&
-            <MapView.Polyline
+            <Polyline
               key="editingPolyline"
               coordinates={this.state.editing.coordinates}
               strokeColor="#F00"
@@ -109,7 +109,7 @@ class PolylineCreator extends React.Component {
 }
 
 PolylineCreator.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/PolylineCreator.js
+++ b/example/examples/PolylineCreator.js
@@ -144,4 +144,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = PolylineCreator;
+export default PolylineCreator;

--- a/example/examples/PriceMarker.js
+++ b/example/examples/PriceMarker.js
@@ -76,4 +76,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = PriceMarker;
+export default PriceMarker;

--- a/example/examples/SetNativePropsOverlays.js
+++ b/example/examples/SetNativePropsOverlays.js
@@ -159,4 +159,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = SetNativePropsOverlays;
+export default SetNativePropsOverlays;

--- a/example/examples/SetNativePropsOverlays.js
+++ b/example/examples/SetNativePropsOverlays.js
@@ -7,7 +7,7 @@ import {
   Dimensions,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Circle, Polygon, Polyline, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -87,7 +87,7 @@ class SetNativePropsOverlays extends React.Component {
           style={styles.map}
           initialRegion={region}
         >
-          <MapView.Circle
+          <Circle
             ref={ref => { this.circle = ref; }}
             center={circle.center}
             radius={circle.radius}
@@ -96,14 +96,14 @@ class SetNativePropsOverlays extends React.Component {
             zIndex={3}
             strokeWidth={3}
           />
-          <MapView.Polygon
+          <Polygon
             ref={ref => { this.polygon = ref; }}
             coordinates={polygon}
             fillColor="rgba(255, 255, 255, 0.6)"
             strokeColor="green"
             strokeWidth={2}
           />
-          <MapView.Polyline
+          <Polyline
             ref={ref => { this.polyline = ref; }}
             coordinates={polyline}
             strokeColor="green"
@@ -133,7 +133,7 @@ class SetNativePropsOverlays extends React.Component {
 }
 
 SetNativePropsOverlays.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/StaticMap.js
+++ b/example/examples/StaticMap.js
@@ -115,4 +115,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = StaticMap;
+export default StaticMap;

--- a/example/examples/StaticMap.js
+++ b/example/examples/StaticMap.js
@@ -6,7 +6,7 @@ import {
   Dimensions,
   ScrollView,
 } from 'react-native';
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -54,7 +54,7 @@ class StaticMap extends React.Component {
             rotateEnabled={false}
             initialRegion={this.state.region}
           >
-            <MapView.Marker
+            <Marker
               title="This is a title"
               description="This is a description"
               coordinate={this.state.region}
@@ -96,7 +96,7 @@ class StaticMap extends React.Component {
 }
 
 StaticMap.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/TakeSnapshot.js
+++ b/example/examples/TakeSnapshot.js
@@ -8,7 +8,7 @@ import {
   Image,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 import flagBlueImg from './assets/flag-blue.png';
 import flagPinkImg from './assets/flag-pink.png';
 
@@ -55,7 +55,7 @@ class MarkerTypes extends React.Component {
             longitudeDelta: LONGITUDE_DELTA,
           }}
         >
-          <MapView.Marker
+          <Marker
             coordinate={{
               latitude: LATITUDE + SPACE,
               longitude: LONGITUDE + SPACE,
@@ -64,7 +64,7 @@ class MarkerTypes extends React.Component {
             anchor={{ x: 0.69, y: 1 }}
             image={flagBlueImg}
           />
-          <MapView.Marker
+          <Marker
             coordinate={{
               latitude: LATITUDE - SPACE,
               longitude: LONGITUDE - SPACE,
@@ -100,7 +100,7 @@ class MarkerTypes extends React.Component {
 }
 
 MarkerTypes.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/TakeSnapshot.js
+++ b/example/examples/TakeSnapshot.js
@@ -135,4 +135,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = MarkerTypes;
+export default MarkerTypes;

--- a/example/examples/ViewsAsMarkers.js
+++ b/example/examples/ViewsAsMarkers.js
@@ -6,7 +6,7 @@ import {
   Dimensions,
   TouchableOpacity,
 } from 'react-native';
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 import PriceMarker from './PriceMarker';
 
 const { width, height } = Dimensions.get('window');
@@ -52,9 +52,9 @@ class ViewsAsMarkers extends React.Component {
           style={styles.map}
           initialRegion={this.state.region}
         >
-          <MapView.Marker coordinate={this.state.coordinate}>
+          <Marker coordinate={this.state.coordinate}>
             <PriceMarker amount={this.state.amount} />
-          </MapView.Marker>
+          </Marker>
         </MapView>
         <View style={styles.buttonContainer}>
           <TouchableOpacity
@@ -76,7 +76,7 @@ class ViewsAsMarkers extends React.Component {
 }
 
 ViewsAsMarkers.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/example/examples/ViewsAsMarkers.js
+++ b/example/examples/ViewsAsMarkers.js
@@ -111,4 +111,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = ViewsAsMarkers;
+export default ViewsAsMarkers;

--- a/example/examples/ZIndexMarkers.js
+++ b/example/examples/ZIndexMarkers.js
@@ -97,4 +97,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = ZIndexMarkers;
+export default ZIndexMarkers;

--- a/example/examples/ZIndexMarkers.js
+++ b/example/examples/ZIndexMarkers.js
@@ -6,7 +6,7 @@ import {
   View,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
 
 const { width, height } = Dimensions.get('window');
 
@@ -41,7 +41,7 @@ class ZIndexMarkers extends React.Component {
 
   render() {
     const markers = this.state.markerInfo.map((markerInfo) =>
-      <MapView.Marker
+      <Marker
         coordinate={markerInfo}
         key={markerInfo.id}
         pinColor={markerInfo.isSpecial ? '#c5a620' : null}
@@ -73,7 +73,7 @@ class ZIndexMarkers extends React.Component {
 }
 
 ZIndexMarkers.propTypes = {
-  provider: MapView.ProviderPropType,
+  provider: ProviderPropType,
 };
 
 const styles = StyleSheet.create({

--- a/index.js
+++ b/index.js
@@ -1,3 +1,14 @@
 import MapView from './lib/components/MapView';
 
-module.exports = MapView;
+export { default as Marker } from './lib/components/MapMarker.js';
+export { default as Polyline } from './lib/components/MapPolyline.js';
+export { default as Polygon } from './lib/components/MapPolygon.js';
+export { default as Circle } from './lib/components/MapCircle.js';
+export { default as UrlTile } from './lib/components/MapUrlTile.js';
+export { default as LocalTile } from './lib/components/MapLocalTile.js';
+export { default as Overlay } from './lib/components/MapOverlay.js';
+export { default as Callout } from './lib/components/MapCallout.js';
+export { default as AnimatedRegion } from './lib/components/AnimatedRegion.js';
+export { Animated, ProviderPropType, MAP_TYPES } from './lib/components/MapView.js';
+
+export default MapView;

--- a/lib/components/MapCallout.js
+++ b/lib/components/MapCallout.js
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = decorateMapComponent(MapCallout, {
+export default decorateMapComponent(MapCallout, {
   componentType: 'Callout',
   providers: {
     google: {

--- a/lib/components/MapCircle.js
+++ b/lib/components/MapCircle.js
@@ -145,7 +145,7 @@ class MapCircle extends React.Component {
 MapCircle.propTypes = propTypes;
 MapCircle.defaultProps = defaultProps;
 
-module.exports = decorateMapComponent(MapCircle, {
+export default decorateMapComponent(MapCircle, {
   componentType: 'Circle',
   providers: {
     google: {

--- a/lib/components/MapLocalTile.js
+++ b/lib/components/MapLocalTile.js
@@ -52,7 +52,7 @@ class MapLocalTile extends React.Component {
 
 MapLocalTile.propTypes = propTypes;
 
-module.exports = decorateMapComponent(MapLocalTile, {
+export default decorateMapComponent(MapLocalTile, {
   componentType: 'LocalTile',
   providers: {
     google: {

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -35,14 +35,14 @@ const propTypes = {
 
   /**
    * The title of the marker. This is only used if the <Marker /> component has no children that
-   * are an `<MapView.Callout />`, in which case the default callout behavior will be used, which
+   * are a `<Callout />`, in which case the default callout behavior will be used, which
    * will show both the `title` and the `description`, if provided.
    */
   title: PropTypes.string,
 
   /**
    * The description of the marker. This is only used if the <Marker /> component has no children
-   * that are an `<MapView.Callout />`, in which case the default callout behavior will be used,
+   * that are a `<Callout />`, in which case the default callout behavior will be used,
    * which will show both the `title` and the `description`, if provided.
    */
   description: PropTypes.string,

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -308,7 +308,7 @@ const styles = StyleSheet.create({
 
 MapMarker.Animated = Animated.createAnimatedComponent(MapMarker);
 
-module.exports = decorateMapComponent(MapMarker, {
+export default decorateMapComponent(MapMarker, {
   componentType: 'Marker',
   providers: {
     google: {

--- a/lib/components/MapOverlay.js
+++ b/lib/components/MapOverlay.js
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 
 MapOverlay.Animated = Animated.createAnimatedComponent(MapOverlay);
 
-module.exports = decorateMapComponent(MapOverlay, {
+export default decorateMapComponent(MapOverlay, {
   componentType: 'Overlay',
   providers: {
     google: {

--- a/lib/components/MapPolygon.js
+++ b/lib/components/MapPolygon.js
@@ -166,7 +166,7 @@ class MapPolygon extends React.Component {
 MapPolygon.propTypes = propTypes;
 MapPolygon.defaultProps = defaultProps;
 
-module.exports = decorateMapComponent(MapPolygon, {
+export default decorateMapComponent(MapPolygon, {
   componentType: 'Polygon',
   providers: {
     google: {

--- a/lib/components/MapPolyline.js
+++ b/lib/components/MapPolyline.js
@@ -162,7 +162,7 @@ class MapPolyline extends React.Component {
 MapPolyline.propTypes = propTypes;
 MapPolyline.defaultProps = defaultProps;
 
-module.exports = decorateMapComponent(MapPolyline, {
+export default decorateMapComponent(MapPolyline, {
   componentType: 'Polyline',
   providers: {
     google: {

--- a/lib/components/MapUrlTile.js
+++ b/lib/components/MapUrlTile.js
@@ -46,7 +46,7 @@ class MapUrlTile extends React.Component {
 
 MapUrlTile.propTypes = propTypes;
 
-module.exports = decorateMapComponent(MapUrlTile, {
+export default decorateMapComponent(MapUrlTile, {
   componentType: 'UrlTile',
   providers: {
     google: {

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -806,6 +806,14 @@ export const Animated = RNAnimated.createAnimatedComponent(MapView);
 
 export const ProviderPropType = PropTypes.oneOf(Object.values(ProviderConstants));
 
+/**
+ * TODO:
+ * All of these properties on MapView are unecessary since they can be imported
+ * individually with the es6 exports in index.js. Removing them is a breaking change,
+ * but potentially allows for better dead code elimination since references are not
+ * kept to components which are never used.
+ */
+
 MapView.Marker = MapMarker;
 MapView.Polyline = MapPolyline;
 MapView.Polygon = MapPolygon;

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {
   EdgeInsetsPropType,
   Platform,
-  Animated,
+  Animated as RNAnimated,
   requireNativeComponent,
   NativeModules,
   ColorPropType,
@@ -28,7 +28,7 @@ import {
 } from './decorateMapComponent';
 import * as ProviderConstants from './ProviderConstants';
 
-const MAP_TYPES = {
+export const MAP_TYPES = {
   STANDARD: 'standard',
   SATELLITE: 'satellite',
   HYBRID: 'hybrid',
@@ -802,6 +802,10 @@ const AIRMapLite = NativeModules.UIManager.AIRMapLite &&
     },
   });
 
+export const Animated = RNAnimated.createAnimatedComponent(MapView);
+
+export const ProviderPropType = PropTypes.oneOf(Object.values(ProviderConstants));
+
 MapView.Marker = MapMarker;
 MapView.Polyline = MapPolyline;
 MapView.Polygon = MapPolygon;
@@ -811,9 +815,9 @@ MapView.LocalTile = MapLocalTile;
 MapView.Overlay = MapOverlay;
 MapView.Callout = MapCallout;
 Object.assign(MapView, ProviderConstants);
-MapView.ProviderPropType = PropTypes.oneOf(Object.values(ProviderConstants));
+MapView.ProviderPropType = ProviderPropType;
 
-MapView.Animated = Animated.createAnimatedComponent(MapView);
+MapView.Animated = Animated;
 MapView.AnimatedRegion = AnimatedRegion;
 
-module.exports = MapView;
+export default MapView;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     }
   },
   "dependencies": {
-    "babel-plugin-module-resolver": "^2.7.1",
-    "babel-preset-react-native": "^1.9.0"
+    "babel-plugin-module-resolver": "^2.3.0",
+    "babel-preset-react-native": "1.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "lint": "eslint ./",
     "build": "npm run build:js && npm run build:android && npm run build:ios",
     "build:js": "exit 0",
-    "build:ios":
-      "bundle install --binstubs ./examples/ios && bundle exec pod install --project-directory=./example/ios/",
+    "build:ios": "bundle install --binstubs ./examples/ios && bundle exec pod install --project-directory=./example/ios/",
     "build:android": "./gradlew :react-native-maps:assembleDebug",
     "ci": "npm run lint",
     "preversion": "./scripts/update-version.js"
@@ -39,9 +38,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",
-    "babel-plugin-module-resolver": "^2.3.0",
     "babel-preset-airbnb": "^1.1.1",
-    "babel-preset-react-native": "1.9.0",
     "eslint": "^3.3.1",
     "eslint-config-airbnb": "^10.0.1",
     "eslint-plugin-import": "^1.14.0",
@@ -58,5 +55,9 @@
     "android": {
       "sourceDir": "./lib/android"
     }
+  },
+  "dependencies": {
+    "babel-plugin-module-resolver": "^2.7.1",
+    "babel-preset-react-native": "^1.9.0"
   }
 }


### PR DESCRIPTION
This allows for the use of react-native-maps without transpilation of modules to CommonJS. That means that it can be imported in projects that don't do such transpilation, which has the advantage of detection of undefined imports, dead code elimination, and generally better static analysis. See #1970 for an example.

Also in the future, it allows for static dead code elimination of code in react-native-maps since it will not be necessary to keep references to components that are not used, e.g. `MapView.Marker`, unless the user explicitly imported that component with 
```
import { Marker } from 'react-native-maps';
```
All documentation and examples have been updated to use these imports but all the components are still attached to the base `MapView` component to avoid a breaking change.

I've checked all the examples - they work for me on Android. I can't see any reason why iOS would be different but I don't have an iOS device to check. I had to make one change to the Events example to prevent warnings relating to event pooling.