### PR TITLE
Updates to build.gradle

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: 'gradle-maven-push.gradle'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.3"
+  compileSdkVersion 26
+  buildToolsVersion "26.0.2"
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 25
+    targetSdkVersion 26
   }
 
   packagingOptions {


### PR DESCRIPTION
Was wondering if it'd be possible to update the sdkVersions and buildToolsVersions used in the android side of the project. In my experience so far, the newer versions of gradle (3.0) require the versions to be at least 26. 