### PR TITLE
Exposing the maximumZ property to AIRMapUrlTile

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ import { UrlTile } from 'react-native-maps';
    * For example, http://c.tile.openstreetmap.org/{z}/{x}/{y}.png
    */
     urlTemplate={this.state.urlTemplate}
+    /**
+     * The maximum zoom level for this tile overlay. Corresponds to the maximumZ setting in
+     * MKTileOverlay. iOS only.
+     */
+    maximumZ={19}
   />
 </MapView>
 ```

--- a/lib/components/MapUrlTile.js
+++ b/lib/components/MapUrlTile.js
@@ -31,6 +31,12 @@ const propTypes = {
    * @platform android
    */
   zIndex: PropTypes.number,
+  /**
+   * The maximum zoom level for this tile overlay. Corresponds to the maximumZ setting in MKTileOverlay. iOS only.
+   *
+   * @platform ios
+   */
+  maximumZ: PropTypes.number,
 };
 
 class MapUrlTile extends React.Component {

--- a/lib/components/MapUrlTile.js
+++ b/lib/components/MapUrlTile.js
@@ -32,7 +32,8 @@ const propTypes = {
    */
   zIndex: PropTypes.number,
   /**
-   * The maximum zoom level for this tile overlay. Corresponds to the maximumZ setting in MKTileOverlay. iOS only.
+   * The maximum zoom level for this tile overlay. Corresponds to the maximumZ setting in
+   * MKTileOverlay. iOS only.
    *
    * @platform ios
    */

--- a/lib/ios/AirMaps/AIRMapUrlTile.h
+++ b/lib/ios/AirMaps/AIRMapUrlTile.h
@@ -24,6 +24,7 @@
 @property (nonatomic, strong) MKTileOverlayRenderer *renderer;
 
 @property (nonatomic, copy) NSString *urlTemplate;
+@property NSInteger maximumZ;
 
 #pragma mark MKOverlay protocol
 

--- a/lib/ios/AirMaps/AIRMapUrlTile.m
+++ b/lib/ios/AirMaps/AIRMapUrlTile.m
@@ -26,6 +26,9 @@
     if (!_urlTemplateSet) return;
     self.tileOverlay = [[MKTileOverlay alloc] initWithURLTemplate:self.urlTemplate];
     self.tileOverlay.canReplaceMapContent = YES;
+    if (self.maximumZ) {
+        self.tileOverlay.maximumZ = self.maximumZ;
+    }
     self.renderer = [[MKTileOverlayRenderer alloc] initWithTileOverlay:self.tileOverlay];
 }
 

--- a/lib/ios/AirMaps/AIRMapUrlTileManager.m
+++ b/lib/ios/AirMaps/AIRMapUrlTileManager.m
@@ -33,5 +33,6 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(urlTemplate, NSString)
+RCT_EXPORT_VIEW_PROPERTY(maximumZ, NSInteger)
 
 @end


### PR DESCRIPTION
Exposing the maximumZ property from MKTileOverlay to javascript so that you can overzoom on custom tiles without the tiles disappearing.