### PR TITLE
Broader peer dependency support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "mapkit"
   ],
   "peerDependencies": {
-    "react": "16.0.0",
-    "react-native": "0.51.0",
-    "prop-types": "^15.5.10"
+    "react": "^16.0",
+    "react-native": "^0.51",
+    "prop-types": "^15.0 || ^16.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
This will remove warnings like this when installing:

```
warning " > react-native-maps@0.20.1" has incorrect peer dependency "react@16.0.0".
warning " > react-native-maps@0.20.1" has incorrect peer dependency "react-native@0.51.0".
warning " > react-native-maps@0.20.1" has unmet peer dependency "prop-types@^15.5.10".
```