### PR TITLE
Fix for pointForCoordinate and coordinateForPoint

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -691,7 +691,7 @@ class MapView extends React.Component {
         return this._mapManagerCommand(name)(this._getHandle(), ...args);
 
       default:
-        break;
+        return Promise.reject(`Invalid platform was passed: ${Platform.OS}`);
     }
   }
 

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -643,18 +643,7 @@ class MapView extends React.Component {
     if (Platform.OS === 'android') {
       return NativeModules.AirMapModule.pointForCoordinate(this._getHandle(), coordinate);
     } else if (Platform.OS === 'ios') {
-      return new Promise((resolve, reject) => {
-        this._runCommand('pointForCoordinate', [
-          coordinate,
-          (err, snapshot) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(snapshot);
-            }
-          },
-        ]);
-      });
+      return this._runCommand('pointForCoordinate', [coordinate]);
     }
     return Promise.reject('pointForCoordinate not supported on this platform');
   }
@@ -668,24 +657,13 @@ class MapView extends React.Component {
    *
    * @return Promise Promise with the coordinate ({ latitude: Number, longitude: Number })
    */
-  coordinateFromPoint(point) {
+  coordinateForPoint(point) {
     if (Platform.OS === 'android') {
-      return NativeModules.AirMapModule.coordinateFromPoint(this._getHandle(), point);
+      return NativeModules.AirMapModule.coordinateForPoint(this._getHandle(), point);
     } else if (Platform.OS === 'ios') {
-      return new Promise((resolve, reject) => {
-        this._runCommand('coordinateFromPoint', [
-          point,
-          (err, snapshot) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(snapshot);
-            }
-          },
-        ]);
-      });
+      return this._runCommand('coordinateForPoint', [point]);
     }
-    return Promise.reject('coordinateFromPoint not supported on this platform');
+    return Promise.reject('coordinateForPoint not supported on this platform');
   }
 
   _uiManagerCommand(name) {
@@ -703,16 +681,14 @@ class MapView extends React.Component {
   _runCommand(name, args) {
     switch (Platform.OS) {
       case 'android':
-        NativeModules.UIManager.dispatchViewManagerCommand(
+        return NativeModules.UIManager.dispatchViewManagerCommand(
           this._getHandle(),
           this._uiManagerCommand(name),
           args
         );
-        break;
 
       case 'ios':
-        this._mapManagerCommand(name)(this._getHandle(), ...args);
-        break;
+        return this._mapManagerCommand(name)(this._getHandle(), ...args);
 
       default:
         break;

--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -316,38 +316,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     self.activityIndicatorView.color = loadingIndicatorColor;
 }
 
-RCT_EXPORT_METHOD(pointForCoordinate:(NSDictionary *)coordinate resolver: (RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
-{
-  CGPoint touchPoint = [self convertCoordinate:
-                        CLLocationCoordinate2DMake(
-                                                   [coordinate[@"lat"] doubleValue],
-                                                   [coordinate[@"lng"] doubleValue]
-                                                   )
-                                 toPointToView:self];
-  
-  resolve(@{
-            @"x": @(touchPoint.x),
-            @"y": @(touchPoint.y),
-            });
-}
-
-RCT_EXPORT_METHOD(coordinateForPoint:(NSDictionary *)point resolver: (RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
-{
-  CLLocationCoordinate2D coordinate = [self convertPoint:
-                                       CGPointMake(
-                                                   [point[@"x"] doubleValue],
-                                                   [point[@"y"] doubleValue]
-                                                   )
-                                    toCoordinateFromView:self];
-  
-  resolve(@{
-            @"lat": @(coordinate.latitude),
-            @"lng": @(coordinate.longitude),
-            });
-}
-
 // Include properties of MKMapView which are only available on iOS 9+
 // and check if their selector is available before calling super method.
 

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -316,6 +316,58 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(pointForCoordinate:(nonnull NSNumber *)reactTag
+                  coordinate: (NSDictionary *)coordinate
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        AIRMap *mapView = (AIRMap *)view;
+        if (![view isKindOfClass:[AIRMap class]]) {
+            reject(@"Invalid argument", [NSString stringWithFormat:@"Invalid view returned from registry, expecting AIRMap, got: %@", view], NULL);
+        } else {
+            CGPoint touchPoint = [mapView convertCoordinate:
+                                  CLLocationCoordinate2DMake(
+                                                             [coordinate[@"lat"] doubleValue],
+                                                             [coordinate[@"lng"] doubleValue]
+                                                             )
+                                              toPointToView:mapView];
+            
+            resolve(@{
+                      @"x": @(touchPoint.x),
+                      @"y": @(touchPoint.y),
+                      });
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(coordinateForPoint:(nonnull NSNumber *)reactTag
+                  point:(NSDictionary *)point
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        AIRMap *mapView = (AIRMap *)view;
+        if (![view isKindOfClass:[AIRMap class]]) {
+            reject(@"Invalid argument", [NSString stringWithFormat:@"Invalid view returned from registry, expecting AIRMap, got: %@", view], NULL);
+        } else {
+            CLLocationCoordinate2D coordinate = [mapView convertPoint:
+                                                 CGPointMake(
+                                                             [point[@"x"] doubleValue],
+                                                             [point[@"y"] doubleValue]
+                                                             )
+                                                 toCoordinateFromView:mapView];
+            
+            resolve(@{
+                      @"lat": @(coordinate.latitude),
+                      @"lng": @(coordinate.longitude),
+                      });
+        }
+    }];
+}
+
 #pragma mark Take Snapshot
 - (void)takeMapSnapshot:(AIRMap *)mapView
         snapshotter:(MKMapSnapshotter *) snapshotter


### PR DESCRIPTION
* Fixed typo "coordinateFromPoint"
* Moved coordinateForPoint/pointForCoordinate from AirMap to AirMapManager
* Fixed how resolve/reject are handled

I have tested on iOS. Yet not confirmed on Android. If anybody can confirm this works on Android, I think this PR is good to go.