### PR TITLE
Check for presence of project-wide gradle configuration properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+## Unreleased
+* Android: Check for presence of Gradle configuration properties that may have been defined by the hosting `rootProject`: `compileSdkVersion`, `buildToolsVersion`, `googlePlayServicesVersion`, `androidMapsUtilsVersion`.  This provides a better mechanism for aligning the requirements of the module with that of the host project.
 
 ## 0.20.1 (February 13, 2018)
 * Common: [hotfix PROVIDER_GOOGLE](https://github.com/react-community/react-native-maps/commit/cd868ea7b33a04c8bdd5e909cf134a133b2cb316)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -107,7 +107,26 @@ The steps are as described in https://facebook.github.io/react-native/docs/runni
    }
    ```
 
-   If you have a different play services than the one included in this library, use the following instead (switch 10.0.1 for the desired version):
+If you've defined *[project-wide properties](https://developer.android.com/studio/build/gradle-tips.html)* (**recommended**) in your root `build.gradle`, this library will detect the presence of the following properties:
+
+    ```groovy
+    buildscript {...}
+    allprojects {...}
+    
+    /**
+     + Project-wide Gradle configuration properties
+     */
+    ext {
+        compileSdkVersion   = 26
+        targetSdkVersion    = 26
+        buildToolsVersion   = "26.0.2"
+        supportLibVersion   = "26.1.0"
+        googlePlayServicesVersion = "11.8.0"
+        androidMapsUtilsVersion = "0.5+"
+    }
+    ```
+
+   If you do **not** have *project-wide properties* defined and have a different play-services version than the one included in this library, use the following instead (switch 10.0.1 for the desired version):
 
    ```groovy
    ...

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -1,13 +1,19 @@
 apply plugin: 'com.android.library'
 apply from: 'gradle-maven-push.gradle'
 
+def DEFAULT_COMPILE_SDK_VERSION             = 25
+def DEFAULT_BUILD_TOOLS_VERSION             = "25.0.3"
+def DEFAULT_TARGET_SDK_VERSION              = 25
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "10.2.4"
+def DEFAULT_ANDROID_MAPS_UTILS_VERSION      = "0.5+"
+
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.3"
+  compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+  buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 25
+    targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
   }
 
   packagingOptions {
@@ -34,8 +40,11 @@ android {
 }
 
 dependencies {
+  def googlePlayServicesVersion = rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+  def androidMapsUtilsVersion   = rootProject.hasProperty('androidMapsUtilsVersion')    ? rootProject.androidMapsUtilsVersion   : DEFAULT_ANDROID_MAPS_UTILS_VERSION
+
   provided "com.facebook.react:react-native:+"
-  compile "com.google.android.gms:play-services-base:10.2.4"
-  compile "com.google.android.gms:play-services-maps:10.2.4"
-  compile 'com.google.maps.android:android-maps-utils:0.5+'
+  compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
+  compile "com.google.android.gms:play-services-maps:$googlePlayServicesVersion"
+  compile "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"
 }


### PR DESCRIPTION
As recommended by the Android Developer Document [Gradle Tips &amp; Tricks](https://developer.android.com/studio/build/gradle-tips.html) (See "*Configure project-wide properties*"), if the hosting application defines the following properties in their root `build.gradle`,  peer modules (like `react-native-maps`) can align its dependencies as requested:

#### 📂 `android/build.gradle`
```diff
buildscript {...}

allprojects {...}

/**
 * Project-wide gradle configuration properties for use by all modules
 */
+ext {
+    compileSdkVersion   = 26
+    targetSdkVersion    = 26
+    buildToolsVersion   = "26.0.2"
+    supportLibVersion   = "26.1.0"
+    googlePlayServicesVersion = "11.8.0"
+    androidMapsUtilsVersion = "0.5+"
+}
```

#### 📂 `android/app/build.gradle`
```diff
android {
+    compileSdkVersion rootProject.compileSdkVersion
+    buildToolsVersion rootProject.buildToolsVersion

    defaultConfig {
+        targetSdkVersion rootProject.targetSdkVersion
    }
}
dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
+    compile "com.android.support:appcompat-v7:$rootProject.supportLibVersion"
     compile "com.facebook.react:react-native:+"  // From node_modules

     compile project(':react-native-background-geolocation')
     compile project(':react-native-background-fetch')
     compile project(':react-native-device-info')
     compile project(':react-native-maps')
}
```
This provides a much better mechanism for aligning `play-services` version than all the nasty business of `exclude group`:

```groovy
   ...
   dependencies {
       ...
       compile(project(':react-native-maps')){
           exclude group: 'com.google.android.gms', module: 'play-services-base'
           exclude group: 'com.google.android.gms', module: 'play-services-maps'
       }
       compile 'com.google.android.gms:play-services-base:10.0.1'
       compile 'com.google.android.gms:play-services-maps:10.0.1'
   }
   ```

Many other modules are beginning to implement this *project-wide configuration properties* mechansism, eg: 
- [`react-native-background-geolocation`](https://github.com/transistorsoft/react-native-background-geolocation)
- [`react-native-background-fetch`](https://github.com/transistorsoft/react-native-background-fetch/blob/master/android/build.gradle#L3-L13)
- [`react-native-device-info`](https://github.com/rebeccahughes/react-native-device-info/blob/master/android/build.gradle#L22)
- [`react-native-firebase`](https://github.com/invertase/react-native-firebase/blob/master/android/build.gradle#L86-L97)