### PR TITLE
add Android support for onPoiClick

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ To run examples:
 
 ```bash
 npm i
-npm start 
+npm start
 
 #Android
 npm run run:android
@@ -396,6 +396,12 @@ Markers are draggable, and emit continuous drag events to update other UI during
 Enable lite mode on Android with `liteMode` prop. Ideal when having multiple maps in a View or ScrollView.
 
 ![](http://i.giphy.com/qZ2lAf18s89na.gif)
+
+### On Poi Click
+
+Poi are clickable, you can can catch the event to get its information (usually to get the full information from Google Place using the placeId).
+
+![](https://media.giphy.com/media/3480VsCKnHr31uCLU3/giphy.gif)
 
 ### Animated Region
 

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Enable lite mode on Android with `liteMode` prop. Ideal when having multiple map
 
 ![](http://i.giphy.com/qZ2lAf18s89na.gif)
 
-### On Poi Click
+### On Poi Click (Google Maps Only)
 
 Poi are clickable, you can catch the event to get its information (usually to get the full detail from Google Place using the placeId).
 

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Enable lite mode on Android with `liteMode` prop. Ideal when having multiple map
 
 ### On Poi Click
 
-Poi are clickable, you can can catch the event to get its information (usually to get the full information from Google Place using the placeId).
+Poi are clickable, you can catch the event to get its information (usually to get the full detail from Google Place using the placeId).
 
 ![](https://media.giphy.com/media/3480VsCKnHr31uCLU3/giphy.gif)
 

--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -50,6 +50,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | `onRegionChangeComplete` | `Region` | Callback that is called once when the region changes, such as when the user is done moving the map.
 | `onPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user taps on the map.
 | `onPanDrag` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user presses and drags the map. **NOTE**: for iOS `scrollEnabled` should be set to false to trigger the event
+| `onPoiClick` | `{ coordinate: LatLng, position: Point, placeId: string, name: string }` | Callback that is called when user click on a POI. **NOTE**: Android only (IOS soon)
 | `onLongPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user makes a "long press" somewhere on the map.
 | `onMarkerPress` |  | Callback that is called when a marker on the map is tapped by the user.
 | `onMarkerSelect` |  | Callback that is called when a marker on the map becomes selected. This will be called when the callout for that marker is about to be shown. **Note**: iOS only.

--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -50,7 +50,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | `onRegionChangeComplete` | `Region` | Callback that is called once when the region changes, such as when the user is done moving the map.
 | `onPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user taps on the map.
 | `onPanDrag` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user presses and drags the map. **NOTE**: for iOS `scrollEnabled` should be set to false to trigger the event
-| `onPoiClick` | `{ coordinate: LatLng, position: Point, placeId: string, name: string }` | Callback that is called when user click on a POI. **NOTE**: Android only (IOS soon)
+| `onPoiClick` | `{ coordinate: LatLng, position: Point, placeId: string, name: string }` | Callback that is called when user click on a POI.
 | `onLongPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user makes a "long press" somewhere on the map.
 | `onMarkerPress` |  | Callback that is called when a marker on the map is tapped by the user.
 | `onMarkerSelect` |  | Callback that is called when a marker on the map becomes selected. This will be called when the callout for that marker is about to be shown. **Note**: iOS only.

--- a/example/App.js
+++ b/example/App.js
@@ -40,6 +40,7 @@ import MapKml from './examples/MapKml';
 import BugMarkerWontUpdate from './examples/BugMarkerWontUpdate';
 import ImageOverlayWithAssets from './examples/ImageOverlayWithAssets';
 import ImageOverlayWithURL from './examples/ImageOverlayWithURL';
+import OnPoiClick from './examples/OnPoiClick';
 
 const IOS = Platform.OS === 'ios';
 const ANDROID = Platform.OS === 'android';
@@ -158,6 +159,7 @@ class App extends React.Component {
       [BugMarkerWontUpdate, 'BUG: Marker Won\'t Update (Android)', true],
       [ImageOverlayWithAssets, 'Image Overlay Component with Assets', true],
       [ImageOverlayWithURL, 'Image Overlay Component with URL', true],
+      [OnPoiClick, 'On Poi Click', true],
     ]
     // Filter out examples that are not yet supported for Google Maps on iOS.
     .filter(example => ANDROID || (IOS && (example[2] || !this.state.useGoogleMaps)))

--- a/example/examples/OnPoiClick.js
+++ b/example/examples/OnPoiClick.js
@@ -4,7 +4,6 @@ import {
   View,
   Text,
   Dimensions,
-  TouchableOpacity,
 } from 'react-native';
 
 import MapView, { Callout, Marker, ProviderPropType } from 'react-native-maps';
@@ -28,7 +27,7 @@ class OnPoiClick extends React.Component {
         latitudeDelta: LATITUDE_DELTA,
         longitudeDelta: LONGITUDE_DELTA,
       },
-      poi: null
+      poi: null,
     };
 
     this.onPoiClick = this.onPoiClick.bind(this);
@@ -38,8 +37,8 @@ class OnPoiClick extends React.Component {
     const poi = e.nativeEvent;
 
     this.setState({
-      poi
-    })
+      poi,
+    });
   }
 
   render() {
@@ -51,18 +50,18 @@ class OnPoiClick extends React.Component {
           initialRegion={this.state.region}
           onPoiClick={this.onPoiClick}
         >
-        {this.state.poi && (
-          <Marker
-            coordinate={this.state.poi.coordinate}
-          >
-            <Callout>
-              <View>
-                <Text>Place Id: { this.state.poi.placeId }</Text>
-                <Text>Name: { this.state.poi.name }</Text>
-              </View>
-            </Callout>
-          </Marker>
-        )}
+          {this.state.poi && (
+            <Marker
+              coordinate={this.state.poi.coordinate}
+            >
+              <Callout>
+                <View>
+                  <Text>Place Id: { this.state.poi.placeId }</Text>
+                  <Text>Name: { this.state.poi.name }</Text>
+                </View>
+              </Callout>
+            </Marker>
+          )}
         </MapView>
       </View>
     );
@@ -81,7 +80,7 @@ const styles = StyleSheet.create({
   },
   map: {
     ...StyleSheet.absoluteFillObject,
-  }
+  },
 });
 
 export default OnPoiClick;

--- a/example/examples/OnPoiClick.js
+++ b/example/examples/OnPoiClick.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  StyleSheet,
+  View,
+  Text,
+  Dimensions,
+  TouchableOpacity,
+} from 'react-native';
+
+import MapView, { Callout, Marker, ProviderPropType } from 'react-native-maps';
+
+const { width, height } = Dimensions.get('window');
+
+const ASPECT_RATIO = width / height;
+const LATITUDE = 37.78825;
+const LONGITUDE = -122.4324;
+const LATITUDE_DELTA = 0.0922;
+const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+
+class OnPoiClick extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      region: {
+        latitude: LATITUDE,
+        longitude: LONGITUDE,
+        latitudeDelta: LATITUDE_DELTA,
+        longitudeDelta: LONGITUDE_DELTA,
+      },
+      poi: null
+    };
+
+    this.onPoiClick = this.onPoiClick.bind(this);
+  }
+
+  onPoiClick(e) {
+    const poi = e.nativeEvent;
+
+    this.setState({
+      poi
+    })
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView
+          provider={this.props.provider}
+          style={styles.map}
+          initialRegion={this.state.region}
+          onPoiClick={this.onPoiClick}
+        >
+        {this.state.poi && (
+          <Marker
+            coordinate={this.state.poi.coordinate}
+          >
+            <Callout>
+              <View>
+                <Text>Place Id: { this.state.poi.placeId }</Text>
+                <Text>Name: { this.state.poi.name }</Text>
+              </View>
+            </Callout>
+          </Marker>
+        )}
+        </MapView>
+      </View>
+    );
+  }
+}
+
+OnPoiClick.propTypes = {
+  provider: ProviderPropType,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    ...StyleSheet.absoluteFillObject,
+  }
+});
+
+export default OnPoiClick;

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,7 @@ declare module "react-native-maps" {
         onMarkerDragStart?: (value: { coordinate: LatLng, position: Point }) => void;
         onMarkerDrag?: (value: { coordinate: LatLng, position: Point }) => void;
         onMarkerDragEnd?: (value: { coordinate: LatLng, position: Point }) => void;
+        onPoiClick?: (value: {coordinate: LatLng, position: Point, placeId: string, name: string }) => void;
         minZoomLevel?: number;
         maxZoomLevel?: number;
         kmlSrc?: string;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -321,7 +321,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         "onMarkerDrag", MapBuilder.of("registrationName", "onMarkerDrag"),
         "onMarkerDragEnd", MapBuilder.of("registrationName", "onMarkerDragEnd"),
         "onPanDrag", MapBuilder.of("registrationName", "onPanDrag"),
-        "onKmlReady", MapBuilder.of("registrationName", "onKmlReady")
+        "onKmlReady", MapBuilder.of("registrationName", "onKmlReady"),
+        "onPoiClick", MapBuilder.of("registrationName", "onPoiClick")
     ));
 
     return map;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -42,6 +42,7 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.android.gms.maps.model.PointOfInterest;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.maps.android.data.kml.KmlContainer;
@@ -63,7 +64,7 @@ import java.util.concurrent.ExecutionException;
 import static android.support.v4.content.PermissionChecker.checkSelfPermission;
 
 public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
-    GoogleMap.OnMarkerDragListener, OnMapReadyCallback {
+    GoogleMap.OnMarkerDragListener, OnMapReadyCallback, GoogleMap.OnPoiClickListener {
   public GoogleMap map;
   private KmlLayer kmlLayer;
   private ProgressBar mapLoadingProgressBar;
@@ -177,6 +178,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     this.map = map;
     this.map.setInfoWindowAdapter(this);
     this.map.setOnMarkerDragListener(this);
+    this.map.setOnPoiClickListener(this);
 
     manager.pushEvent(context, this, "onMapReady", new WritableNativeMap());
 
@@ -786,6 +788,16 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     AirMapMarker markerView = getMarkerMap(marker);
     event = makeClickEventData(marker.getPosition());
     manager.pushEvent(context, markerView, "onDragEnd", event);
+  }
+
+  @Override
+  public void onPoiClick(PointOfInterest poi) {
+    WritableMap event = makeClickEventData(poi.latLng);
+
+    event.putString("placeId", poi.placeId);
+    event.putString("name", poi.name);
+
+    manager.pushEvent(context, this, "onPoiClick", event);
   }
 
   private ProgressBar getMapLoadingProgressBar() {

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -378,6 +378,11 @@ const propTypes = {
   onPanDrag: PropTypes.func,
 
   /**
+   * Callback that is called when user click on a POI
+   */
+  onPoiClick: PropTypes.func,
+
+  /**
    * Callback that is called when a marker on the map is tapped by the user.
    */
   onMarkerPress: PropTypes.func,

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -27,6 +27,7 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onLongPress;
 @property (nonatomic, copy) RCTBubblingEventBlock onMarkerPress;
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
+@property (nonatomic, copy) RCTBubblingEventBlock onPoiClick;
 @property (nonatomic, copy) RCTDirectEventBlock onRegionChange;
 @property (nonatomic, copy) RCTDirectEventBlock onRegionChangeComplete;
 @property (nonatomic, strong) NSMutableArray *markers;
@@ -56,6 +57,7 @@
 - (void)didLongPressAtCoordinate:(CLLocationCoordinate2D)coordinate;
 - (void)didChangeCameraPosition:(GMSCameraPosition *)position;
 - (void)idleAtCameraPosition:(GMSCameraPosition *)position;
+- (void)didTapPOIWithPlaceID:(NSString *)placeID name:(NSString *) name location:(CLLocationCoordinate2D) location;
 
 + (MKCoordinateRegion)makeGMSCameraPositionFromMap:(GMSMapView *)map andGMSCameraPosition:(GMSCameraPosition *)position;
 + (GMSCameraPosition*)makeGMSCameraPositionFromMap:(GMSMapView *)map andMKCoordinateRegion:(MKCoordinateRegion)region;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -259,6 +259,20 @@ id regionAsJSON(MKCoordinateRegion region) {
   if (self.onChange) self.onChange(event);
 }
 
+- (void)didTapPOIWithPlaceID:(NSString *)placeID
+                        name:(NSString *)name
+                    location:(CLLocationCoordinate2D)location {
+  id event = @{@"placeId": placeID,
+               @"name": name,
+               @"coordinate": @{
+                   @"latitude": @(location.latitude),
+                   @"longitude": @(location.longitude)
+                   }
+               };
+
+  if (self.onPoiClick) self.onPoiClick(event);
+}
+
 - (void)idleAtCameraPosition:(GMSCameraPosition *)position {
   id event = @{@"continuous": @NO,
                @"region": regionAsJSON([AIRGoogleMap makeGMSCameraPositionFromMap:self andGMSCameraPosition:position]),
@@ -417,7 +431,7 @@ id regionAsJSON(MKCoordinateRegion region) {
       }
     }
   }
-  
+
   return marker.style.iconUrl;
 }
 
@@ -426,28 +440,28 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 - (void)setKmlSrc:(NSString *)kmlUrl {
-    
+
   _kmlSrc = kmlUrl;
-  
+
   NSURL *url = [NSURL URLWithString:kmlUrl];
   NSData *urlData = nil;
-  
+
   if ([url isFileURL]) {
     urlData = [NSData dataWithContentsOfURL:url];
   } else {
     urlData = [[NSFileManager defaultManager] contentsAtPath:kmlUrl];
   }
-  
+
   GMUKMLParser *parser = [[GMUKMLParser alloc] initWithData:urlData];
   [parser parse];
-  
+
   NSUInteger index = 0;
   NSMutableArray *markers = [[NSMutableArray alloc]init];
 
   for (GMUPlacemark *place in parser.placemarks) {
-        
+
     CLLocationCoordinate2D location =((GMUPoint *) place.geometry).coordinate;
-    
+
     AIRGoogleMapMarker *marker = (AIRGoogleMapMarker *)[[AIRGoogleMapMarkerManager alloc] view];
     if (!marker.bridge) {
       marker.bridge = _bridge;
@@ -460,9 +474,9 @@ id regionAsJSON(MKCoordinateRegion region) {
     marker.imageSrc = [AIRGoogleMap GetIconUrl:place parser:parser];
     marker.layer.backgroundColor = [UIColor clearColor].CGColor;
     marker.layer.position = CGPointZero;
-      
+
     [self insertReactSubview:(UIView *) marker atIndex:index];
-    
+
     [markers addObject:@{@"id": marker.identifier,
                          @"title": marker.title,
                          @"description": marker.subtitle,
@@ -474,7 +488,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 
     index++;
   }
-  
+
   id event = @{@"markers": markers};
   if (self.onKmlReady) self.onKmlReady(event);
 }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -70,6 +70,7 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMarkerPress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onRegionChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onRegionChangeComplete, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPoiClick, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(mapType, GMSMapViewType)
 RCT_EXPORT_VIEW_PROPERTY(minZoomLevel, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(maxZoomLevel, CGFloat)
@@ -303,16 +304,16 @@ RCT_EXPORT_METHOD(pointForCoordinate:(nonnull NSNumber *)reactTag
                              [coordinate[@"latitude"] doubleValue],
                              [coordinate[@"longitude"] doubleValue]
                              );
-  
+
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     id view = viewRegistry[reactTag];
     if (![view isKindOfClass:[AIRGoogleMap class]]) {
       RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
     } else {
       AIRGoogleMap *mapView = (AIRGoogleMap *)view;
-      
+
       CGPoint touchPoint = [mapView.projection pointForCoordinate:coord];
-      
+
       callback(@[[NSNull null], @{
                    @"x": @(touchPoint.x),
                    @"y": @(touchPoint.y),
@@ -329,16 +330,16 @@ RCT_EXPORT_METHOD(coordinateForPoint:(nonnull NSNumber *)reactTag
                            [point[@"x"] doubleValue],
                            [point[@"y"] doubleValue]
                            );
-  
+
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     id view = viewRegistry[reactTag];
     if (![view isKindOfClass:[AIRGoogleMap class]]) {
       RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
     } else {
       AIRGoogleMap *mapView = (AIRGoogleMap *)view;
-      
+
       CLLocationCoordinate2D coordinate = [mapView.projection coordinateForPoint:pt];
-      
+
       callback(@[[NSNull null], @{
                 @"latitude": @(coordinate.latitude),
                 @"longitude": @(coordinate.longitude),
@@ -435,5 +436,13 @@ RCT_EXPORT_METHOD(setMapBoundaries:(nonnull NSNumber *)reactTag
 - (void)mapView:(GMSMapView *)mapView didDragMarker:(GMSMarker *)marker {
   AIRGMSMarker *aMarker = (AIRGMSMarker *)marker;
   [aMarker.fakeMarker didDragMarker:aMarker];
+}
+
+- (void)mapView:(GMSMapView *)mapView
+    didTapPOIWithPlaceID:(NSString *)placeID
+                    name:(NSString *)name
+                location:(CLLocationCoordinate2D)location {
+    AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
+    [googleMapView didTapPOIWithPlaceID:placeID name:name location:location];
 }
 @end


### PR DESCRIPTION
Exposes the onPoiClick event to react-native-maps wrapper.
It send back the location of the poi, the name and the googleId (docs updated)

I haven't dug in IOS implementation yet since I'm more confortable with android. But I'll definitely do it through a next PR ! (or if anyone is keen to, feel free)

Let me know if any other steps need to be done 👍 