### PR TITLE
Stop marker event propagation in order to prevent onPress for MapView…

### DIFF
--- a/docs/marker.md
+++ b/docs/marker.md
@@ -19,6 +19,7 @@
 | `draggable` | `<null>` |  | This is a non-value based prop. Adding this allows the marker to be draggable (re-positioned).
 | `tracksViewChanges` | `Boolean` | true | Sets whether this marker should track view changes. It's recommended to turn it off whenever it's possible to improve custom marker performance. **Note**: iOS Google Maps only.
 | `tracksInfoWindowChanges` | `Boolean` | false | Sets whether this marker should track view changes in info window. Enabling it will let marker change content of info window after first render pass, but will lead to decreased performance, so it's recommended to disable it whenever you don't need it. **Note**: iOS Google Maps only.
+| `stopPropagation` | `Boolean` | false | Sets whether this marker should propagate `onPress` events. Enabling it will stop the parent `MapView`'s `onPress` from being called. **Note**: iOS only. Android does not propagate `onPress` events. See [#1132](https://github.com/react-community/react-native-maps/issues/1132) for more information.
 
 ## Events
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -146,6 +146,7 @@ declare module "react-native-maps" {
         rotation?: number;
         tracksViewChanges?: boolean
         tracksInfoWindowChanges?: boolean
+        stopPropagation?: boolean
     }
 
     export interface MapPolylineProps {

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -226,10 +226,6 @@ const propTypes = {
   onDragEnd: PropTypes.func,
 };
 
-const defaultProps = {
-  onPress() {},
-};
-
 class MapMarker extends React.Component {
   constructor(props) {
     super(props);
@@ -295,13 +291,18 @@ class MapMarker extends React.Component {
         {...this.props}
         image={image}
         style={[styles.marker, this.props.style]}
+        onPress={event => {
+          event.stopPropagation();
+          if (this.props.onPress) {
+            this.props.onPress(event);
+          }
+        }}
       />
     );
   }
 }
 
 MapMarker.propTypes = propTypes;
-MapMarker.defaultProps = defaultProps;
 MapMarker.viewConfig = viewConfig;
 
 const styles = StyleSheet.create({

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -186,6 +186,14 @@ const propTypes = {
   tracksInfoWindowChanges: PropTypes.bool,
 
   /**
+   * Stops Marker onPress events from propagating to and triggering MapView onPress events.
+   *
+   * @platform ios
+   */
+
+  stopPropagation: PropTypes.bool,
+
+  /**
    * Callback that is called when the user presses on the marker
    */
   onPress: PropTypes.func,
@@ -224,6 +232,10 @@ const propTypes = {
    * will want to setState on the marker's coordinate again
    */
   onDragEnd: PropTypes.func,
+};
+
+const defaultProps = {
+  stopPropagation: false,
 };
 
 class MapMarker extends React.Component {
@@ -292,7 +304,9 @@ class MapMarker extends React.Component {
         image={image}
         style={[styles.marker, this.props.style]}
         onPress={event => {
-          event.stopPropagation();
+          if (this.props.stopPropagation) {
+            event.stopPropagation();
+          }
           if (this.props.onPress) {
             this.props.onPress(event);
           }
@@ -303,6 +317,7 @@ class MapMarker extends React.Component {
 }
 
 MapMarker.propTypes = propTypes;
+MapMarker.defaultProps = defaultProps;
 MapMarker.viewConfig = viewConfig;
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Stop marker event propagation in order to prevent onPress for MapViews from being called when a marker is clicked. This makes the behavior of Apple Maps identical to that of the behavior of Google Maps on Android. This fixes react-community/react-native-maps#1132.

<!--
  PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

  **What happens if you SKIP this step?**

  Your pull request will NOT be evaluated!

  PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

  Thanks for helping us help you!
-->


### Is there any other PR opened that does the same ?

<!--

**Please keep in mind that we aplly the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**


If it exists please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)

 -->

No, not that I've seen. Nothing is referenced in any of the issues I've come across either.

### What issue is this PR fixing

https://github.com/react-community/react-native-maps/issues/1132


<!--
  Thanks for your contribution :)
-->