### PR TITLE
Fix example project setup

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ target '_YOUR_PROJECT_TARGET_' do
     'RCTText',
     'RCTVibration',
     'RCTWebSocket',
-    'BatchedBridge', // REMOVE THIS if you use RN 0.54+
+    'BatchedBridge', # REMOVE THIS if you use RN 0.54+
   ]
 
   pod 'react-native-maps', path: rn_maps_path

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -20,7 +20,7 @@ target 'AirMapsExplorer' do
     'RCTText',
     'RCTVibration',
     'RCTWebSocket',
-    'BatchedBridge', // REMOVE THIS if you use RN 0.54+
+    'BatchedBridge', # REMOVE THIS if you use RN 0.54+
   ]
 
   pod 'GoogleMaps'  # Remove this line if you don't want to support GoogleMaps on iOS


### PR DESCRIPTION
### Is there any other PR opened that does the same ?

https://github.com/react-community/react-native-maps/pull/2065

This clearly wasn't tested - the Podfile contains a syntax error, which causes `pod install` to fail.

### What issue is this PR fixing?

Uses Ruby-style comment in the Podfile & example doc.

### How did you test this PR?

Followed https://github.com/react-community/react-native-maps/blob/master/docs/examples-setup.md and it works now after this change.