### PR TITLE
Updated gradle configuration for gradle 3.0.0+

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -107,7 +107,7 @@ The steps are as described in https://facebook.github.io/react-native/docs/runni
    ...
    dependencies {
      ...
-     compile project(':react-native-maps')
+     implementation project(':react-native-maps')
    }
    ```
 
@@ -136,12 +136,12 @@ If you've defined *[project-wide properties](https://developer.android.com/studi
    ...
    dependencies {
        ...
-       compile(project(':react-native-maps')){
+       implementation(project(':react-native-maps')){
            exclude group: 'com.google.android.gms', module: 'play-services-base'
            exclude group: 'com.google.android.gms', module: 'play-services-maps'
        }
-       compile 'com.google.android.gms:play-services-base:10.0.1'
-       compile 'com.google.android.gms:play-services-maps:10.0.1'
+       implementation 'com.google.android.gms:play-services-base:10.0.1'
+       implementation 'com.google.android.gms:play-services-maps:10.0.1'
    }
    ```
 

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -43,8 +43,8 @@ dependencies {
   def googlePlayServicesVersion = rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
   def androidMapsUtilsVersion   = rootProject.hasProperty('androidMapsUtilsVersion')    ? rootProject.androidMapsUtilsVersion   : DEFAULT_ANDROID_MAPS_UTILS_VERSION
 
-  provided "com.facebook.react:react-native:+"
-  compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
-  compile "com.google.android.gms:play-services-maps:$googlePlayServicesVersion"
-  compile "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"
+  compileOnly "com.facebook.react:react-native:+"
+  implementation "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
+  implementation "com.google.android.gms:play-services-maps:$googlePlayServicesVersion"
+  implementation "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"
 }


### PR DESCRIPTION
Further details on Gradle 3.0.0+ https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#new_configurations


### Is there any other PR opened that does the same ?

No.

### What issue is this PR fixing

https://github.com/react-community/react-native-maps/issues/2095

Also fixing installation.md which had the old gradle configuration and not the new one.