### PR TITLE
permit android vector drawables to be used as markers

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.drawable.Animatable;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -283,7 +284,15 @@ public class AirMapMarker extends AirMapFeature {
     } else {
       iconBitmapDescriptor = getBitmapDescriptorByName(uri);
       if (iconBitmapDescriptor != null) {
-          iconBitmap = BitmapFactory.decodeResource(getResources(), getDrawableResourceByName(uri));
+          int drawableId = getDrawableResourceByName(uri);
+          iconBitmap = BitmapFactory.decodeResource(getResources(), drawableId);
+          if (iconBitmap == null) { // VectorDrawable or similar
+              Drawable drawable = getResources().getDrawable(drawableId);
+              iconBitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+              drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
+              Canvas canvas = new Canvas(iconBitmap);
+              drawable.draw(canvas);
+          }
       }
       update();
     }


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### How did you test this PR?

On Android, add a [vector drawable resource](https://developer.android.com/guide/topics/graphics/vector-drawable-resources.html) to the native code. ([Here](https://github.com/googlesamples/android-topeka/blob/master/app/src/main/res/drawable-v21/ic_cross.xml) is a sample if you need one.) Then, try to use it as the {{marker}} parameter. Previously, an exception would be thrown; with this PR, it now works:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'int android.graphics.Bitmap.getWidth()' on a null object reference
    at com.airbnb.android.react.maps.AirMapMarker.getIcon(AirMapMarker.java:330)
    at com.airbnb.android.react.maps.AirMapMarker.createMarkerOptions(AirMapMarker.java:360)
    at com.airbnb.android.react.maps.AirMapMarker.getMarkerOptions(AirMapMarker.java:294)
    at com.airbnb.android.react.maps.AirMapMarker.addToMap(AirMapMarker.java:316)
    at com.airbnb.android.react.maps.AirMapView.addFeature(AirMapView.java:513)
    at com.airbnb.android.react.maps.AirMapManager.addView(AirMapManager.java:361)
    at com.airbnb.android.react.maps.AirMapManager.addView(AirMapManager.java:28)
```