### PR TITLE
Add Mock Provider boolean on each location update

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -49,7 +49,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | `onKmlReady` | `KmlContainer` | Callback that is called once the kml is fully loaded.
 | `onRegionChange` | `Region` | Callback that is called continuously when the region changes, such as when a user is dragging the map.
 | `onRegionChangeComplete` | `Region` | Callback that is called once when the region changes, such as when the user is done moving the map.
-| `onUserLocationChange` | `{ coordinate: LatLng }` | Callback that is called when the underlying map figures our users current location. Make sure **showsUserLocation** is set to *true* and that the provider is `"google"`.
+| `onUserLocationChange` | `{ coordinate: LatLng }` | Callback that is called when the underlying map figures our users current location (coordinate also includes isFromMockProvider value for Android). Make sure **showsUserLocation** is set to *true* and that the provider is `"google"`.
 | `onPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user taps on the map.
 | `onPanDrag` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user presses and drags the map. **NOTE**: for iOS `scrollEnabled` should be set to false to trigger the event
 | `onPoiClick` | `{ coordinate: LatLng, position: Point, placeId: string, name: string }` | Callback that is called when user click on a POI.

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -196,6 +196,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         coordinate.putDouble("altitude", location.getAltitude());
         coordinate.putDouble("accuracy", location.getAccuracy());
         coordinate.putDouble("speed", location.getSpeed());
+        coordinate.putBoolean("isFromMockProvider", location.isFromMockProvider());
+         
         event.putMap("coordinate", coordinate);
 
         manager.pushEvent(context, view, "onUserLocationChange", event);


### PR DESCRIPTION
### Does any other open PR do the same thing?
No

### What issue is this PR fixing?
This adds a check to whether the returned location is authentic or mocked

### How did you test this PR?
Tested it on my application where I am checking for mock providers

1. Set showsUserLocation={true} in MapView component
2. Set 'google' as your map provider
3. Listen for onUserLocationChange which will return a callback with lat,long,speed,accuracy & boolean for isFromMockProvider

(Works only for Android)
I have tested this on Android (real device)
