### PR TITLE
Add takeSnapshot method to MapView type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,8 +104,9 @@ declare module "react-native-maps" {
         animateToViewingAngle(angle: number, duration?: number): void;
         fitToElements(animated: boolean): void;
         fitToSuppliedMarkers(markers: string[], animated: boolean): void;
-        fitToCoordinates(coordinates?: LatLng[], options?:{}): void;
+        fitToCoordinates(coordinates?: LatLng[], options?: {}): void;
         setMapBoundaries(northEast: LatLng, southWest: LatLng): void;
+        takeSnapshot(options?: SnapshotOptions): Promise<string>;
     }
 
     export class MapViewAnimated extends React.Component<MapViewProps, any> {
@@ -115,8 +116,18 @@ declare module "react-native-maps" {
         animateToViewingAngle(angle: number, duration?: number): void;
         fitToElements(animated: boolean): void;
         fitToSuppliedMarkers(markers: string[], animated: boolean): void;
-        fitToCoordinates(coordinates?: LatLng[], options?:{}): void;
+        fitToCoordinates(coordinates?: LatLng[], options?: {}): void;
         setMapBoundaries(northEast: LatLng, southWest: LatLng): void;
+        takeSnapshot(options?: SnapshotOptions): Promise<string>;
+    }
+
+    export interface SnapshotOptions {
+        width?: number;              // optional, when omitted the view-width is used
+        height?: number;             // optional, when omitted the view-height is used
+        region?: Region;             // iOS only, optional region to render
+        format?: 'png' | 'jpg';      // image formats: 'png', 'jpg' (default: 'png')
+        quality?: number;            // image quality: 0..1 (only relevant for jpg, default: 1)
+        result?: 'file' | 'base64';  // result types: 'file', 'base64' (default: 'file')
     }
 
     export type LineCapType = 'butt' | 'round' | 'square';


### PR DESCRIPTION
According to specs at https://github.com/react-community/react-native-maps#take-snapshot-of-map

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No.

### What issue is this PR fixing?

None. It adds typings.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Tested on all platforms by modifying the typings.

<!--
Thanks for your contribution :)
-->
