### PR TITLE
v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Change Log
-## Unreleased
-* Android: Check for presence of Gradle configuration properties that may have been defined by the hosting `rootProject`: `compileSdkVersion`, `buildToolsVersion`, `googlePlayServicesVersion`, `androidMapsUtilsVersion`.  This provides a better mechanism for aligning the requirements of the module with that of the host project.
+## 0.21.0 (March 31, 2018)
+* Common: [#2030](https://github.com/react-community/react-native-maps/pull/2030) Broadened peer-dependency support
+* Common: [#2035](https://github.com/react-community/react-native-maps/pull/2035), [#2113](https://github.com/react-community/react-native-maps/pull/2113), & [#2141](https://github.com/react-community/react-native-maps/pull/2141) Typescript improvements and fixes
+* Common: [#2011](https://github.com/react-community/react-native-maps/pull/2011) Add suport for KML file (Only Markers)
+* Common: [#2053](https://github.com/react-community/react-native-maps/pull/2053) Fix 'module undefined' for React Native >= 0.54
+* Common: [#2131](https://github.com/react-community/react-native-maps/pull/2131) Fix initialRegion for React Native >= 0.54
+* Common: [#2115](https://github.com/react-community/react-native-maps/pull/2115) Upgrade React Native peer dependency to 0.54
+* Common: [#2032](https://github.com/react-community/react-native-maps/pull/2032) Add onMyLocationChange event
+* Common: [#2039](https://github.com/react-community/react-native-maps/pull/2039) Fixed problem with pointForCoordinate and coordinateForPoint methods
+* Common: [#2050](https://github.com/react-community/react-native-maps/pull/2050) Add support for onPoiClick
+* iOS: [#2022](https://github.com/react-community/react-native-maps/pull/2022) Add support for Map.Overlay
+* iOS: [#2068](https://github.com/react-community/react-native-maps/pull/2068) Prevent marker press from calling MapView onPress
+* iOS: [#2057](https://github.com/react-community/react-native-maps/pull/2057) Fixed polygon and polyline not re-rendering when changing tile URL (AirMaps)
+* iOS: [#2101](https://github.com/react-community/react-native-maps/pull/2101) Fixed re-render not updating MapView.Circle component in UI when radius or center coordinates change (AirMaps)
+* Android: [#2111](https://github.com/react-community/react-native-maps/pull/2111) Allow vector drawables to be used as markers
+* Android: [#2132](https://github.com/react-community/react-native-maps/pull/2132) Add mock-provider boolean on each location update
+* Android: [#2047](https://github.com/react-community/react-native-maps/pull/2047) Check for presence of project-wide (ext) Gradle configuration properties `compileSdkVersion`, `targetSdkVersion`, `buildToolsVersion`, `supportLibVersion`, `googlePlayServicesVersion`, and `androidMapsUtilsVersion`. This provides a better mechanism for aligning the requirements of the module with that of the host project.
+* Android: [#2096](https://github.com/react-community/react-native-maps/pull/2096) Updated gradle configuration for gradle 3.0.0+
 
 ## 0.20.1 (February 13, 2018)
 * Common: [hotfix PROVIDER_GOOGLE](https://github.com/react-community/react-native-maps/commit/cd868ea7b33a04c8bdd5e909cf134a133b2cb316)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -29,11 +29,11 @@ PODS:
     - GoogleMaps/Base
   - React (0.54.2):
     - React/Core (= 0.54.2)
-  - react-native-google-maps (0.20.1):
+  - react-native-google-maps (0.21.0):
     - Google-Maps-iOS-Utils (= 2.1.0)
     - GoogleMaps (= 2.5.0)
     - React
-  - react-native-maps (0.20.1):
+  - react-native-maps (0.21.0):
     - React
   - React/Core (0.54.2):
     - yoga (= 0.54.2.React)

--- a/lib/android/gradle.properties
+++ b/lib/android/gradle.properties
@@ -1,5 +1,5 @@
 VERSION_CODE=4
-VERSION_NAME=0.20.1
+VERSION_NAME=0.21.0
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=React Native Map view component for Android

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native Mapview component for iOS + Android",
   "main": "index.js",
   "author": "Leland Richardson <leland.m.richardson@gmail.com>",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "run:packager": "./node_modules/react-native/packager/packager.sh",


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

Nope!

### What issue is this PR fixing?

Quite a few. Just packing up everything from the past 2 months for a new release!
### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

N/A

<!--
Thanks for your contribution :)
-->

Following semantic versioning practices and based on the amount of time and number of changes between `master` and `v0.20.1` I opted to create a new minor version (0.21.0) than a new patch (0.20.2). However, it is my opinion that this would be an appropriate time to jump to the first **major** version (1.0.0) given the recent change in repository ownership and the maturity, size, and comprehensiveness of this library. [It is typically appropriate to move from 0.X.X to 1.X.X once the public API is defined](https://semver.org/#spec-item-5).

I made these commits one file at a time, so whoever merges this should squash them into one.