### PR TITLE
Fixed `pointForCoordinate`/`coordinateForPoint` Promises in iOS (#2039, #2061)

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -298,7 +298,8 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
 
 RCT_EXPORT_METHOD(pointForCoordinate:(nonnull NSNumber *)reactTag
                   coordinate:(NSDictionary *)coordinate
-                  withCallback:(RCTResponseSenderBlock)callback)
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
   CLLocationCoordinate2D coord =
   CLLocationCoordinate2DMake(
@@ -314,18 +315,19 @@ RCT_EXPORT_METHOD(pointForCoordinate:(nonnull NSNumber *)reactTag
       AIRGoogleMap *mapView = (AIRGoogleMap *)view;
 
       CGPoint touchPoint = [mapView.projection pointForCoordinate:coord];
-
-      callback(@[[NSNull null], @{
-                   @"x": @(touchPoint.x),
-                   @"y": @(touchPoint.y),
-                   }]);
+      
+      resolve(@{
+                @"x": @(touchPoint.x),
+                @"y": @(touchPoint.y),
+                });
     }
   }];
 }
 
 RCT_EXPORT_METHOD(coordinateForPoint:(nonnull NSNumber *)reactTag
                   point:(NSDictionary *)point
-                  withCallback:(RCTResponseSenderBlock)callback)
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
   CGPoint pt = CGPointMake(
                            [point[@"x"] doubleValue],
@@ -340,11 +342,11 @@ RCT_EXPORT_METHOD(coordinateForPoint:(nonnull NSNumber *)reactTag
       AIRGoogleMap *mapView = (AIRGoogleMap *)view;
 
       CLLocationCoordinate2D coordinate = [mapView.projection coordinateForPoint:pt];
-
-      callback(@[[NSNull null], @{
+      
+      resolve(@{
                 @"latitude": @(coordinate.latitude),
                 @"longitude": @(coordinate.longitude),
-                }]);
+                });
     }
   }];
 }


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Changes to these functions that did not reflect in both providers. Currently the API is broken - expecting callback in GoogleMaps and returning Promise in Air. While the docs says it returns Promise.

### How did you test this PR?

Written simple code with `await` to print results of both functions, in Air and Google provider.

