### PR TITLE
Fix Xcode warnings for format, pointer type, unused var

### DIFF
--- a/lib/ios/AirMaps/AIRMapLocalTileOverlay.m
+++ b/lib/ios/AirMaps/AIRMapLocalTileOverlay.m
@@ -16,9 +16,9 @@
 
 -(void)loadTileAtPath:(MKTileOverlayPath)path result:(void (^)(NSData *, NSError *))result {
     NSMutableString *tileFilePath = [self.URLTemplate mutableCopy];
-    [tileFilePath replaceOccurrencesOfString: @"{x}" withString:[NSString stringWithFormat:@"%i", path.x] options:NULL range:NSMakeRange(0, tileFilePath.length)];
-    [tileFilePath replaceOccurrencesOfString:@"{y}" withString:[NSString stringWithFormat:@"%i", path.y] options:NULL range:NSMakeRange(0, tileFilePath.length)];
-    [tileFilePath replaceOccurrencesOfString:@"{z}" withString:[NSString stringWithFormat:@"%i", path.z] options:NULL range:NSMakeRange(0, tileFilePath.length)];
+    [tileFilePath replaceOccurrencesOfString: @"{x}" withString:[NSString stringWithFormat:@"%li", (long)path.x] options:0 range:NSMakeRange(0, tileFilePath.length)];
+    [tileFilePath replaceOccurrencesOfString:@"{y}" withString:[NSString stringWithFormat:@"%li", (long)path.y] options:0 range:NSMakeRange(0, tileFilePath.length)];
+    [tileFilePath replaceOccurrencesOfString:@"{z}" withString:[NSString stringWithFormat:@"%li", (long)path.z] options:0 range:NSMakeRange(0, tileFilePath.length)];
     if ([[NSFileManager defaultManager] fileExistsAtPath:tileFilePath]) {
         NSData* tile = [NSData dataWithContentsOfFile:tileFilePath];
         result(tile,nil);

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -810,7 +810,6 @@ static int kDragCenterContext;
     BOOL needZoom = NO;
     CGFloat newLongitudeDelta = 0.0f;
     MKCoordinateRegion region = mapView.region;
-    CGFloat zoomLevel = [self zoomLevel:mapView];
     // On iOS 7, it's possible that we observe invalid locations during initialization of the map.
     // Filter those out.
     if (!CLLocationCoordinate2DIsValid(region.center)) {


### PR DESCRIPTION
We noticed these warnings when using this library inside Expo. Changed NULL to 0 for the NSStringCompareOptions flag; cast the NSIntegers to long when using as a string format argument; removed unused variable zoomLevel.

### Does any other open PR do the same thing?

Not as far as I can tell.

### What issue is this PR fixing?

There are some annoying compiler warnings in Xcode and this makes them go away.

### How did you test this PR?

I compiled the lib.