### PR TITLE
Fix color prop types

### DIFF
--- a/lib/components/MapCircle.js
+++ b/lib/components/MapCircle.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
+  ColorPropType,
   ViewPropTypes,
   View,
 } from 'react-native';
@@ -44,12 +45,12 @@ const propTypes = {
   /**
    * The stroke color to use for the path.
    */
-  strokeColor: PropTypes.string,
+  strokeColor: ColorPropType,
 
   /**
    * The fill color to use for the path.
    */
-  fillColor: PropTypes.string,
+  fillColor: ColorPropType,
 
   /**
    * The order in which this tile overlay is drawn with respect to other overlays. An overlay

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
+  ColorPropType,
   StyleSheet,
   Platform,
   NativeModules,
@@ -62,7 +63,7 @@ const propTypes = {
    * If no custom marker view or custom image is provided, the platform default pin will be used,
    * which can be customized by this color. Ignored if a custom marker is being used.
    */
-  pinColor: PropTypes.string,
+  pinColor: ColorPropType,
 
   /**
    * The coordinate for the marker.

--- a/lib/components/MapPolygon.js
+++ b/lib/components/MapPolygon.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
+  ColorPropType,
   ViewPropTypes,
   View,
 } from 'react-native';
@@ -56,12 +57,12 @@ const propTypes = {
   /**
    * The stroke color to use for the path.
    */
-  strokeColor: PropTypes.string,
+  strokeColor: ColorPropType,
 
   /**
    * The fill color to use for the path.
    */
-  fillColor: PropTypes.string,
+  fillColor: ColorPropType,
 
   /**
    * The order in which this tile overlay is drawn with respect to other overlays. An overlay

--- a/lib/components/MapPolyline.js
+++ b/lib/components/MapPolyline.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
+  ColorPropType,
   ViewPropTypes,
   View,
 } from 'react-native';
@@ -39,7 +40,7 @@ const propTypes = {
   /**
    * The fill color to use for the path.
    */
-  fillColor: PropTypes.string,
+  fillColor: ColorPropType,
 
   /**
    * The stroke width to use for the path.
@@ -49,12 +50,12 @@ const propTypes = {
   /**
    * The stroke color to use for the path.
    */
-  strokeColor: PropTypes.string,
+  strokeColor: ColorPropType,
 
   /**
    * The stroke colors to use for the path.
    */
-  strokeColors: PropTypes.arrayOf(PropTypes.string),
+  strokeColors: PropTypes.arrayOf(ColorPropType),
 
   /**
    * The order in which this tile overlay is drawn with respect to other overlays. An overlay


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Using react-native's `ColorPropType` to validate all color props more accurately.

More specifically I'm doing this to avoid getting yellow box alerts when using different formats for colors. For instance, using `setNormalizedColorAlpha()` I have colors defined as integers in my app.

### How did you test this PR?

Just tested against my app, both in iOS and Android. Colors still work/no more alerts.