### PR TITLE
Add comment about NSLocationWhenInUseUsageDescription

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -90,7 +90,9 @@ const propTypes = {
    *
    * **NOTE**: You need to add NSLocationWhenInUseUsageDescription key in
    * Info.plist to enable geolocation, otherwise it is going
-   * to *fail silently*!
+   * to *fail silently*! You will also need to add an explanation for why
+   * you need the users location against `NSLocationWhenInUseUsageDescription` in Info.plist.
+   * Otherwise Apple may reject your app submission.
    */
   showsUserLocation: PropTypes.bool,
 


### PR DESCRIPTION
ref. https://github.com/react-community/react-native-maps/pull/2181

> Apple are now rejecting app submissions without an explanation of why you need to user's location.

Does any other open PR do the same thing?
No

What issue is this PR fixing?
> Explaining a required step for location tracking, which will prevent Apple rejecting an app 

How did you test this PR?
I just added  comment. No code changes.
