### PR TITLE
respect `tappable` prop on android

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygon.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygon.java
@@ -23,6 +23,7 @@ public class AirMapPolygon extends AirMapFeature {
   private int fillColor;
   private float strokeWidth;
   private boolean geodesic;
+  private boolean tappable;
   private float zIndex;
 
   public AirMapPolygon(Context context) {
@@ -95,6 +96,13 @@ public class AirMapPolygon extends AirMapFeature {
     }
   }
 
+  public void setTappable(boolean tapabble) {
+    this.tappable = tapabble;
+    if (polygon != null) {
+      polygon.setClickable(tappable);
+    }
+  }
+
   public void setGeodesic(boolean geodesic) {
     this.geodesic = geodesic;
     if (polygon != null) {
@@ -142,7 +150,7 @@ public class AirMapPolygon extends AirMapFeature {
   @Override
   public void addToMap(GoogleMap map) {
     polygon = map.addPolygon(getPolygonOptions());
-    polygon.setClickable(true);
+    polygon.setClickable(this.tappable);
   }
 
   @Override

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygonManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygonManager.java
@@ -68,6 +68,11 @@ public class AirMapPolygonManager extends ViewGroupManager<AirMapPolygon> {
     view.setStrokeColor(color);
   }
 
+  @ReactProp(name = "tappable", defaultBoolean = false)
+  public void setTappable(AirMapPolygon view, boolean tapabble) {
+    view.setTappable(tapabble);
+  }
+
   @ReactProp(name = "geodesic", defaultBoolean = false)
   public void setGeodesic(AirMapPolygon view, boolean geodesic) {
     view.setGeodesic(geodesic);


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

https://github.com/react-community/react-native-maps/issues/1002

### How did you test this PR?

1. Create a `Polygon` and tap on it on Android.
2. Observe `onPress` event from Map.
3. Add `tappable` prop to polygon.
4. Observe lack of `onPress` event from Map.
