### PR TITLE
Make tiles display at the same physical size regardless of pixel dens…

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -481,7 +481,7 @@ id regionAsJSON(MKCoordinateRegion region) {
                     @"latitude": @(location.coordinate.latitude),
                     @"longitude": @(location.coordinate.longitude),
                     @"altitude": @(location.altitude),
-+                   @"timestamp": @(location.timestamp.timeIntervalSinceReferenceDate * 1000),
+                    @"timestamp": @(location.timestamp.timeIntervalSinceReferenceDate * 1000),
                     @"accuracy": @(location.horizontalAccuracy),
                     @"altitudeAccuracy": @(location.verticalAccuracy),
                     @"speed": @(location.speed),

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -481,7 +481,7 @@ id regionAsJSON(MKCoordinateRegion region) {
                     @"latitude": @(location.coordinate.latitude),
                     @"longitude": @(location.coordinate.longitude),
                     @"altitude": @(location.altitude),
-                    @"timestamp": @(location.timestamp),
++                   @"timestamp": @(location.timestamp.timeIntervalSinceReferenceDate * 1000),
                     @"accuracy": @(location.horizontalAccuracy),
                     @"altitudeAccuracy": @(location.verticalAccuracy),
                     @"speed": @(location.speed),

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTile.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTile.m
@@ -17,6 +17,7 @@
 {
   _urlTemplate = urlTemplate;
   _tileLayer = [GMSURLTileLayer tileLayerWithURLConstructor:[self _getTileURLConstructor]];
+  _tileLayer.tileSize = [[UIScreen mainScreen] scale] * 256;
 }
 
 - (GMSTileURLConstructor)_getTileURLConstructor


### PR DESCRIPTION
…ity on iOS devices

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

Not that I know of.

### What issue is this PR fixing?

https://github.com/react-community/react-native-maps/issues/2242

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

This makes UrlTile, when using Google Maps API, behave the same way on iOS as it currently does on Android. That is, displaying tiles at the same physical size regardless of pixel density.

Have tested on simulators iPhone X and iPhone 6, as well as a physical iPhone 5S device.

Here is a snack, which should also work without Expo: https://snack.expo.io/@jmr/urltile-ios-tile-size

Without my modification it will display the tiles very tiny on high dpi devices, and with the modification it will display them at the same size regardless.

<!--
Thanks for your contribution :)
-->
