### PR TITLE
[iOS] Prefix or eliminate globals in AIRMapMarker

### DIFF
--- a/lib/ios/AirMaps/AIRMapMarker.m
+++ b/lib/ios/AirMaps/AIRMapMarker.m
@@ -14,17 +14,18 @@
 #import <React/RCTImageLoader.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
-NSInteger const CALLOUT_OPEN_ZINDEX_BASELINE = 999;
+
+NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
 
 @implementation AIREmptyCalloutBackgroundView
-bool _calloutIsOpen = NO;
-NSInteger _zIndexBeforeOpen = 0;
 @end
 
 @implementation AIRMapMarker {
     BOOL _hasSetCalloutOffset;
     RCTImageLoaderCancellationBlock _reloadImageCancellationBlock;
     MKPinAnnotationView *_pinView;
+    BOOL _calloutIsOpen;
+    NSInteger _zIndexBeforeOpen;
 }
 
 - (void)reactSetFrame:(CGRect)frame
@@ -307,7 +308,7 @@ NSInteger _zIndexBeforeOpen = 0;
 - (void)setZIndex:(NSInteger)zIndex
 {
     _zIndexBeforeOpen = zIndex;
-    _zIndex = _calloutIsOpen ? zIndex + CALLOUT_OPEN_ZINDEX_BASELINE : zIndex;
+    _zIndex = _calloutIsOpen ? zIndex + AIR_CALLOUT_OPEN_ZINDEX_BASELINE : zIndex;
     self.layer.zPosition = zIndex;
 }
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

Not as far as I can tell

### What issue is this PR fixing?

`AIRMapMarker`'s implementation file contains a few global variables, some of which appear to be mistakes (they're being used as though they were instance variables of AIRMapMarker, so I made them actually be instance  vars) and one which is a legitimate constant that I prefixed with `AIR`. These global symbols prevent the library from being vendored (e.g. for Expo) because they collide with other copies of the library. This solves that.

### How did you test this PR?

Build the project and include it as a vendored library with other copies of itself.