### PR TITLE
Fixes warnings about self

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -224,7 +224,7 @@ CGRect unionRect(CGRect a, CGRect b) {
                                                                  dispatch_async(dispatch_get_main_queue(), ^{
 
                                                                    // TODO(gil): This way allows different image sizes
-                                                                   if (_iconImageView) [_iconImageView removeFromSuperview];
+                                                                   if (self->_iconImageView) [self->_iconImageView removeFromSuperview];
 
                                                                    // ... but this way is more efficient?
 //                                                                   if (_iconImageView) {
@@ -250,7 +250,7 @@ CGRect unionRect(CGRect a, CGRect b) {
                                                                    CGRect selfBounds = unionRect(bounds, self.bounds);
                                                                    [self setFrame:selfBounds];
 
-                                                                   _iconImageView = imageView;
+                                                                   self->_iconImageView = imageView;
                                                                    [self iconViewInsertSubview:imageView atIndex:0];
                                                                  });
                                                                }];


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Explicitly mentioning self warning

### How did you test this PR?

Built application and warnings went away

Fixes the following warnings that I saw when building an application that used this package:

```
13:05:49]: ▸ ⚠️  /Users/kyledecot/code/root-react-native/node_modules/react-native-maps/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m:226:72: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended be]
havior [-Wimplicit-retain-self]
[13:05:49]: ▸ if (_iconImageView) [_iconImageView removeFromSuperview];
[13:05:49]: ▸            ^
[13:05:49]: ▸ ⚠️  /Users/kyledecot/code/root-react-native/node_modules/react-native-maps/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m:226:89: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended be]
havior [-Wimplicit-retain-self]
[13:05:49]: ▸ if (_iconImageView) [_iconImageView removeFromSuperview];
[13:05:49]: ▸                                                                        ^
[13:05:49]: ▸ ⚠️  /Users/kyledecot/code/root-react-native/node_modules/react-native-maps/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m:252:68: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended be]
havior [-Wimplicit-retain-self]
[13:05:49]: ▸ _iconImageView = imageView;
[13:05:49]: ▸
```
