### PR TITLE
coordinateForPoint/pointForCoordinate worked with coordinate shorthands on AirMaps

### DIFF
--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -354,8 +354,8 @@ RCT_EXPORT_METHOD(pointForCoordinate:(nonnull NSNumber *)reactTag
         } else {
             CGPoint touchPoint = [mapView convertCoordinate:
                                   CLLocationCoordinate2DMake(
-                                                             [coordinate[@"lat"] doubleValue],
-                                                             [coordinate[@"lng"] doubleValue]
+                                                             [coordinate[@"latitude"] doubleValue],
+                                                             [coordinate[@"longitude"] doubleValue]
                                                              )
                                               toPointToView:mapView];
             
@@ -386,8 +386,8 @@ RCT_EXPORT_METHOD(coordinateForPoint:(nonnull NSNumber *)reactTag
                                                  toCoordinateFromView:mapView];
             
             resolve(@{
-                      @"lat": @(coordinate.latitude),
-                      @"lng": @(coordinate.longitude),
+                      @"latitude": @(coordinate.latitude),
+                      @"longitude": @(coordinate.longitude),
                       });
         }
     }];


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

coordinateForPoint/pointForCoordinate in AirMaps are working differently than Google Maps. The coordinates are lat/lng instead of latitude/longitude, which is a mistake and is incompatible with this library.

### How did you test this PR?

Tested on an iOS 11 simulator, my own project, while trying AirMaps.

