### PR TITLE
Add custom indoor picker level

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -62,6 +62,8 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | `onMarkerDragStart` | `{ coordinate: LatLng, position: Point }` | Callback that is called when the user initiates a drag on a marker (if it is draggable)
 | `onMarkerDrag` | `{ coordinate: LatLng, position: Point }` | Callback called continuously as a marker is dragged
 | `onMarkerDragEnd` | `{ coordinate: LatLng, position: Point }` | Callback that is called when a drag on a marker finishes. This is usually the point you will want to setState on the marker's coordinate again
+| `onIndoorLevelActivated` | `IndoorLevel` | Callback that is called when a level on indoor building is activated
+| `onIndoorBuildingFocused` | `IndoorBuilding` | Callback that is called when a indoor building is focused/unfocused
 
 
 
@@ -75,6 +77,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | `animateToBearing` | `bearing: Number`, `duration: Number` |
 | `animateToViewingAngle` | `angle: Number`, `duration: Number` |
 | `setMapBoundaries` | `northEast: LatLng`, `southWest: LatLng` | `GoogleMaps only`
+| `setIndoorActiveLevelIndex` | `levelIndex: Number` |
 | `fitToElements` | `animated: Boolean` |
 | `fitToSuppliedMarkers` | `markerIDs: String[]`, `animated: Boolean` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to call it from the MapView `onLayout` event.
@@ -159,5 +162,21 @@ type Marker {
 ```
 type KmlContainer {
   markers: [Marker]
+}
+```
+
+```
+type IndoorBuilding {
+  underground: boolean,
+  activeLevelIndex: Number,
+  levels: Array<IndoorLevel>,
+}
+```
+
+```
+type IndoorLevel {
+  activeLevelIndex: Number,
+  name: String,
+  shortName: String,
 }
 ```

--- a/example/App.js
+++ b/example/App.js
@@ -42,6 +42,7 @@ import ImageOverlayWithAssets from './examples/ImageOverlayWithAssets';
 import ImageOverlayWithURL from './examples/ImageOverlayWithURL';
 import AnimatedNavigation from './examples/AnimatedNavigation';
 import OnPoiClick from './examples/OnPoiClick';
+import IndoorMap from './examples/IndoorMap';
 
 const IOS = Platform.OS === 'ios';
 const ANDROID = Platform.OS === 'android';
@@ -162,6 +163,7 @@ class App extends React.Component {
       [ImageOverlayWithURL, 'Image Overlay Component with URL', true],
       [AnimatedNavigation, 'Animated Map Navigation', true],
       [OnPoiClick, 'On Poi Click', true],
+      [IndoorMap, 'Indoor Map', true],
     ]
     // Filter out examples that are not yet supported for Google Maps on iOS.
     .filter(example => ANDROID || (IOS && (example[2] || !this.state.useGoogleMaps)))

--- a/example/examples/IndoorMap.js
+++ b/example/examples/IndoorMap.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  StyleSheet,
+  View,
+  Dimensions,
+  Button,
+  Alert,
+} from 'react-native';
+ import MapView from 'react-native-maps';
+ const { width, height } = Dimensions.get('window');
+ const ASPECT_RATIO = width / height;
+const LATITUDE = 1.3039991;
+const LONGITUDE = 103.8316911;
+// const LATITUDE = 37.6167451;
+// const LONGITUDE = -122.3876189;
+const LATITUDE_DELTA = 0.003;
+const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+ class IndoorMap extends React.Component {
+  constructor(props) {
+    super(props);
+    this.setIndoorLevel = this.setIndoorLevel.bind(this);
+  }
+   handleIndoorFocus(event) {
+    const { indoorBuilding } = event.nativeEvent;
+    const { defaultLevelIndex, levels } = indoorBuilding;
+    const levelNames = levels.map(lv => lv.name || '');
+    const msg = `Default Level: ${defaultLevelIndex}\nLevels: ${levelNames.toString()}`;
+    Alert.alert(
+      'Indoor building focused',
+      msg
+    );
+  }
+   setIndoorLevel(level) {
+    this.map.setIndoorActiveLevelIndex(level);
+  }
+   render() {
+    return (
+      <View style={styles.container}>
+        <MapView
+          provider={this.props.provider}
+          style={styles.map}
+          initialRegion={{
+            latitude: LATITUDE,
+            longitude: LONGITUDE,
+            latitudeDelta: LATITUDE_DELTA,
+            longitudeDelta: LONGITUDE_DELTA,
+          }}
+          showsIndoors
+          showsIndoorLevelPicker
+          onIndoorBuildingFocused={this.handleIndoorFocus}
+          ref={map => { this.map = map; }}
+        />
+        <Button title="go to level 5" onPress={() => { this.setIndoorLevel(5); }} />
+        <Button title="go to level 1" onPress={() => { this.setIndoorLevel(1); }} />
+      </View>
+    );
+  }
+}
+ IndoorMap.propTypes = {
+  provider: MapView.ProviderPropType,
+};
+ const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});
+ module.exports = IndoorMap;

--- a/example/examples/IndoorMap.js
+++ b/example/examples/IndoorMap.js
@@ -1,72 +1,71 @@
 import React from 'react';
-import {
-  StyleSheet,
-  View,
-  Dimensions,
-  Button,
-  Alert,
-} from 'react-native';
- import MapView from 'react-native-maps';
- const { width, height } = Dimensions.get('window');
- const ASPECT_RATIO = width / height;
+import { StyleSheet, View, Dimensions, Button, Alert } from 'react-native';
+import MapView from 'react-native-maps';
+const { width, height } = Dimensions.get('window');
+const ASPECT_RATIO = width / height;
 const LATITUDE = 1.3039991;
 const LONGITUDE = 103.8316911;
-// const LATITUDE = 37.6167451;
-// const LONGITUDE = -122.3876189;
 const LATITUDE_DELTA = 0.003;
 const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
- class IndoorMap extends React.Component {
-  constructor(props) {
-    super(props);
-    this.setIndoorLevel = this.setIndoorLevel.bind(this);
-  }
-   handleIndoorFocus(event) {
-    const { indoorBuilding } = event.nativeEvent;
-    const { defaultLevelIndex, levels } = indoorBuilding;
-    const levelNames = levels.map(lv => lv.name || '');
-    const msg = `Default Level: ${defaultLevelIndex}\nLevels: ${levelNames.toString()}`;
-    Alert.alert(
-      'Indoor building focused',
-      msg
-    );
-  }
-   setIndoorLevel(level) {
-    this.map.setIndoorActiveLevelIndex(level);
-  }
-   render() {
-    return (
-      <View style={styles.container}>
-        <MapView
-          provider={this.props.provider}
-          style={styles.map}
-          initialRegion={{
-            latitude: LATITUDE,
-            longitude: LONGITUDE,
-            latitudeDelta: LATITUDE_DELTA,
-            longitudeDelta: LONGITUDE_DELTA,
-          }}
-          showsIndoors
-          showsIndoorLevelPicker
-          onIndoorBuildingFocused={this.handleIndoorFocus}
-          ref={map => { this.map = map; }}
-        />
-        <Button title="go to level 5" onPress={() => { this.setIndoorLevel(5); }} />
-        <Button title="go to level 1" onPress={() => { this.setIndoorLevel(1); }} />
-      </View>
-    );
-  }
+
+class IndoorMap extends React.Component {
+    constructor(props) {
+        super(props);
+        this.setIndoorLevel = this.setIndoorLevel.bind(this);
+    }
+   
+    handleIndoorFocus(event) {
+        const { indoorBuilding } = event.nativeEvent;
+        const { defaultLevelIndex, levels } = indoorBuilding;
+        const levelNames = levels.map(lv => lv.name || '');
+        const msg = `Default Level: ${defaultLevelIndex}\nLevels: ${levelNames.toString()}`;
+        Alert.alert(
+            'Indoor building focused',
+            msg
+        );
+    }
+    
+    setIndoorLevel(level) {
+        this.map.setIndoorActiveLevelIndex(level);
+    }
+   
+    render() {
+        return (
+        <View style={styles.container}>
+            <MapView
+            provider={this.props.provider}
+            style={styles.map}
+            initialRegion={{
+                latitude: LATITUDE,
+                longitude: LONGITUDE,
+                latitudeDelta: LATITUDE_DELTA,
+                longitudeDelta: LONGITUDE_DELTA,
+            }}
+            showsIndoors
+            showsIndoorLevelPicker
+            onIndoorBuildingFocused={this.handleIndoorFocus}
+            ref={map => { this.map = map; }}
+            />
+            <Button title="go to level 5" onPress={() => { this.setIndoorLevel(5); }} />
+            <Button title="go to level 1" onPress={() => { this.setIndoorLevel(1); }} />
+        </View>
+        );
+    }
 }
- IndoorMap.propTypes = {
+
+IndoorMap.propTypes = {
   provider: MapView.ProviderPropType,
 };
- const styles = StyleSheet.create({
-  container: {
-    ...StyleSheet.absoluteFillObject,
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-  },
-  map: {
-    ...StyleSheet.absoluteFillObject,
-  },
+ 
+const styles = StyleSheet.create({
+    container: {
+        ...StyleSheet.absoluteFillObject,
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+    },
+    map: {
+        ...StyleSheet.absoluteFillObject,
+    },
 });
- module.exports = IndoorMap;
+
+module.exports = IndoorMap;

--- a/example/examples/IndoorMap.js
+++ b/example/examples/IndoorMap.js
@@ -11,46 +11,46 @@ const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 
 class IndoorMap extends React.Component {
   constructor(props) {
-      super(props);
-      this.setIndoorLevel = this.setIndoorLevel.bind(this);
+    super(props);
+    this.setIndoorLevel = this.setIndoorLevel.bind(this);
   }
 
   handleIndoorFocus(event) {
-      const { indoorBuilding } = event.nativeEvent;
-      const { defaultLevelIndex, levels } = indoorBuilding;
-      const levelNames = levels.map(lv => lv.name || '');
-      const msg = `Default Level: ${defaultLevelIndex}\nLevels: ${levelNames.toString()}`;
-      Alert.alert(
-          'Indoor building focused',
-          msg
-      );
+    const { indoorBuilding } = event.nativeEvent;
+    const { defaultLevelIndex, levels } = indoorBuilding;
+    const levelNames = levels.map(lv => lv.name || '');
+    const msg = `Default Level: ${defaultLevelIndex}\nLevels: ${levelNames.toString()}`;
+    Alert.alert(
+      'Indoor building focused',
+      msg
+    );
   }
 
   setIndoorLevel(level) {
-      this.map.setIndoorActiveLevelIndex(level);
+    this.map.setIndoorActiveLevelIndex(level);
   }
 
   render() {
-      return (
+    return (
       <View style={styles.container}>
-          <MapView
+        <MapView
           provider={this.props.provider}
           style={styles.map}
           initialRegion={{
-              latitude: LATITUDE,
-              longitude: LONGITUDE,
-              latitudeDelta: LATITUDE_DELTA,
-              longitudeDelta: LONGITUDE_DELTA,
+            latitude: LATITUDE,
+            longitude: LONGITUDE,
+            latitudeDelta: LATITUDE_DELTA,
+            longitudeDelta: LONGITUDE_DELTA,
           }}
           showsIndoors
           showsIndoorLevelPicker
           onIndoorBuildingFocused={this.handleIndoorFocus}
           ref={map => { this.map = map; }}
-          />
-          <Button title="go to level 5" onPress={() => { this.setIndoorLevel(5); }} />
-          <Button title="go to level 1" onPress={() => { this.setIndoorLevel(1); }} />
+        />
+        <Button title="go to level 5" onPress={() => { this.setIndoorLevel(5); }} />
+        <Button title="go to level 1" onPress={() => { this.setIndoorLevel(1); }} />
       </View>
-      );
+    );
   }
 }
 
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   map: {
-      ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFillObject,
   },
 });
 

--- a/example/examples/IndoorMap.js
+++ b/example/examples/IndoorMap.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, Dimensions, Button, Alert } from 'react-native';
 import MapView from 'react-native-maps';
+
 const { width, height } = Dimensions.get('window');
 const ASPECT_RATIO = width / height;
 const LATITUDE = 1.3039991;
@@ -9,63 +10,63 @@ const LATITUDE_DELTA = 0.003;
 const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 
 class IndoorMap extends React.Component {
-    constructor(props) {
-        super(props);
-        this.setIndoorLevel = this.setIndoorLevel.bind(this);
-    }
-   
-    handleIndoorFocus(event) {
-        const { indoorBuilding } = event.nativeEvent;
-        const { defaultLevelIndex, levels } = indoorBuilding;
-        const levelNames = levels.map(lv => lv.name || '');
-        const msg = `Default Level: ${defaultLevelIndex}\nLevels: ${levelNames.toString()}`;
-        Alert.alert(
-            'Indoor building focused',
-            msg
-        );
-    }
-    
-    setIndoorLevel(level) {
-        this.map.setIndoorActiveLevelIndex(level);
-    }
-   
-    render() {
-        return (
-        <View style={styles.container}>
-            <MapView
-            provider={this.props.provider}
-            style={styles.map}
-            initialRegion={{
-                latitude: LATITUDE,
-                longitude: LONGITUDE,
-                latitudeDelta: LATITUDE_DELTA,
-                longitudeDelta: LONGITUDE_DELTA,
-            }}
-            showsIndoors
-            showsIndoorLevelPicker
-            onIndoorBuildingFocused={this.handleIndoorFocus}
-            ref={map => { this.map = map; }}
-            />
-            <Button title="go to level 5" onPress={() => { this.setIndoorLevel(5); }} />
-            <Button title="go to level 1" onPress={() => { this.setIndoorLevel(1); }} />
-        </View>
-        );
-    }
+  constructor(props) {
+      super(props);
+      this.setIndoorLevel = this.setIndoorLevel.bind(this);
+  }
+
+  handleIndoorFocus(event) {
+      const { indoorBuilding } = event.nativeEvent;
+      const { defaultLevelIndex, levels } = indoorBuilding;
+      const levelNames = levels.map(lv => lv.name || '');
+      const msg = `Default Level: ${defaultLevelIndex}\nLevels: ${levelNames.toString()}`;
+      Alert.alert(
+          'Indoor building focused',
+          msg
+      );
+  }
+
+  setIndoorLevel(level) {
+      this.map.setIndoorActiveLevelIndex(level);
+  }
+
+  render() {
+      return (
+      <View style={styles.container}>
+          <MapView
+          provider={this.props.provider}
+          style={styles.map}
+          initialRegion={{
+              latitude: LATITUDE,
+              longitude: LONGITUDE,
+              latitudeDelta: LATITUDE_DELTA,
+              longitudeDelta: LONGITUDE_DELTA,
+          }}
+          showsIndoors
+          showsIndoorLevelPicker
+          onIndoorBuildingFocused={this.handleIndoorFocus}
+          ref={map => { this.map = map; }}
+          />
+          <Button title="go to level 5" onPress={() => { this.setIndoorLevel(5); }} />
+          <Button title="go to level 1" onPress={() => { this.setIndoorLevel(1); }} />
+      </View>
+      );
+  }
 }
 
 IndoorMap.propTypes = {
   provider: MapView.ProviderPropType,
 };
- 
+
 const styles = StyleSheet.create({
-    container: {
-        ...StyleSheet.absoluteFillObject,
-        justifyContent: 'flex-end',
-        alignItems: 'center',
-    },
-    map: {
-        ...StyleSheet.absoluteFillObject,
-    },
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+      ...StyleSheet.absoluteFillObject,
+  },
 });
 
 module.exports = IndoorMap;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -341,7 +341,10 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         "onMarkerDragEnd", MapBuilder.of("registrationName", "onMarkerDragEnd"),
         "onPanDrag", MapBuilder.of("registrationName", "onPanDrag"),
         "onKmlReady", MapBuilder.of("registrationName", "onKmlReady"),
-        "onPoiClick", MapBuilder.of("registrationName", "onPoiClick"),
+        "onPoiClick", MapBuilder.of("registrationName", "onPoiClick")
+    ));
+
+    map.putAll(MapBuilder.of(
         "onIndoorLevelActivated", MapBuilder.of("registrationName", "onIndoorLevelActivated"),
         "onIndoorBuildingFocused", MapBuilder.of("registrationName", "onIndoorBuildingFocused")
     ));
@@ -360,12 +363,12 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         "fitToElements", FIT_TO_ELEMENTS,
         "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS,
         "fitToCoordinates", FIT_TO_COORDINATES,
-        "animateToNavigation", ANIMATE_TO_NAVIGATION,
-        "setIndoorActiveLevelIndex", SET_INDOOR_ACTIVE_LEVEL_INDEX
+        "animateToNavigation", ANIMATE_TO_NAVIGATION
     );
 
     map.putAll(MapBuilder.of(
-      "setMapBoundaries", SET_MAP_BOUNDARIES
+      "setMapBoundaries", SET_MAP_BOUNDARIES,
+      "setIndoorActiveLevelIndex", SET_INDOOR_ACTIVE_LEVEL_INDEX
     ));
 
     return map;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -37,7 +37,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   private static final int FIT_TO_SUPPLIED_MARKERS = 6;
   private static final int FIT_TO_COORDINATES = 7;
   private static final int SET_MAP_BOUNDARIES = 8;
-  private static final int ANIMATE_TO_NAVIGATION = 9;
+  private static final int ANIMATE_TO_NAVIGATION = 9; 
+  private static final int SET_INDOOR_ACTIVE_LEVEL_INDEX = 10;
 
 
   private final Map<String, Integer> MAP_TYPES = MapBuilder.of(
@@ -313,6 +314,10 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
       case SET_MAP_BOUNDARIES:
         view.setMapBoundaries(args.getMap(0), args.getMap(1));
         break;
+
+      case SET_INDOOR_ACTIVE_LEVEL_INDEX:
+        view.setIndoorActiveLevelIndex(args.getInt(0));
+        break;
     }
   }
 
@@ -336,7 +341,9 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         "onMarkerDragEnd", MapBuilder.of("registrationName", "onMarkerDragEnd"),
         "onPanDrag", MapBuilder.of("registrationName", "onPanDrag"),
         "onKmlReady", MapBuilder.of("registrationName", "onKmlReady"),
-        "onPoiClick", MapBuilder.of("registrationName", "onPoiClick")
+        "onPoiClick", MapBuilder.of("registrationName", "onPoiClick"),
+        "onIndoorLevelActivated", MapBuilder.of("registrationName", "onIndoorLevelActivated"),
+        "onIndoorBuildingFocused", MapBuilder.of("registrationName", "onIndoorBuildingFocused")
     ));
 
     return map;
@@ -353,7 +360,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         "fitToElements", FIT_TO_ELEMENTS,
         "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS,
         "fitToCoordinates", FIT_TO_COORDINATES,
-        "animateToNavigation", ANIMATE_TO_NAVIGATION
+        "animateToNavigation", ANIMATE_TO_NAVIGATION,
+        "setIndoorActiveLevelIndex", SET_INDOOR_ACTIVE_LEVEL_INDEX
     );
 
     map.putAll(MapBuilder.of(

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -598,11 +598,11 @@ class MapView extends React.Component {
   setMapBoundaries(northEast, southWest) {
     this._runCommand('setMapBoundaries', [northEast, southWest]);
   }
-  
+
   setIndoorActiveLevelIndex(activeLevelIndex) {
     this._runCommand('setIndoorActiveLevelIndex', [activeLevelIndex]);
   }
-  
+
   /**
    * Takes a snapshot of the map and saves it to a picture
    * file or returns the image as a base64 encoded string.

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -455,12 +455,12 @@ const propTypes = {
    */
   kmlSrc: PropTypes.string,
 
-   /**
+  /**
    * Callback that is called when a level is activated on a indoor building.
    */
   onIndoorLevelActivated: PropTypes.func,
-  
-   /**
+
+  /**
    * Callback that is called when a Building is focused.
    */
   onIndoorBuildingFocused: PropTypes.func,
@@ -602,7 +602,7 @@ class MapView extends React.Component {
   setIndoorActiveLevelIndex(activeLevelIndex) {
     this._runCommand('setIndoorActiveLevelIndex', [activeLevelIndex]);
   }
-
+  
   /**
    * Takes a snapshot of the map and saves it to a picture
    * file or returns the image as a base64 encoded string.

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -455,6 +455,15 @@ const propTypes = {
    */
   kmlSrc: PropTypes.string,
 
+   /**
+   * Callback that is called when a level is activated on a indoor building.
+   */
+  onIndoorLevelActivated: PropTypes.func,
+  
+   /**
+   * Callback that is called when a Building is focused.
+   */
+  onIndoorBuildingFocused: PropTypes.func,
 };
 
 class MapView extends React.Component {
@@ -588,6 +597,10 @@ class MapView extends React.Component {
 
   setMapBoundaries(northEast, southWest) {
     this._runCommand('setMapBoundaries', [northEast, southWest]);
+  }
+  
+  setIndoorActiveLevelIndex(activeLevelIndex) {
+    this._runCommand('setIndoorActiveLevelIndex', [activeLevelIndex]);
   }
 
   /**

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -32,6 +32,8 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onPoiClick;
 @property (nonatomic, copy) RCTDirectEventBlock onRegionChange;
 @property (nonatomic, copy) RCTDirectEventBlock onRegionChangeComplete;
+@property (nonatomic, copy) RCTDirectEventBlock onIndoorLevelActivated;
+@property (nonatomic, copy) RCTDirectEventBlock onIndoorBuildingFocused;
 @property (nonatomic, strong) NSMutableArray *markers;
 @property (nonatomic, strong) NSMutableArray *polygons;
 @property (nonatomic, strong) NSMutableArray *polylines;
@@ -48,6 +50,7 @@
 @property (nonatomic, assign) BOOL pitchEnabled;
 @property (nonatomic, assign) BOOL showsUserLocation;
 @property (nonatomic, assign) BOOL showsMyLocationButton;
+@property (nonatomic, assign) BOOL showsIndoors;
 @property (nonatomic, assign) BOOL showsIndoorLevelPicker;
 @property (nonatomic, assign) NSString *kmlSrc;
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -425,6 +425,14 @@ id regionAsJSON(MKCoordinateRegion region) {
   [self setMinZoom:self.minZoom maxZoom:maxZoomLevel ];
 }
 
+- (void)setShowsIndoors:(BOOL)showsIndoors {
+  self.indoorEnabled = showsIndoors;
+}
+
+- (BOOL)showsIndoors {
+  return self.indoorEnabled;
+}
+
 - (void)setShowsIndoorLevelPicker:(BOOL)showsIndoorLevelPicker {
   self.settings.indoorPicker = showsIndoorLevelPicker;
 }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
@@ -6,7 +6,9 @@
 //
 
 #import <React/RCTViewManager.h>
+#import "AIRGoogleMap.h"
 
 @interface AIRGoogleMapManager : RCTViewManager
+@property (nonatomic, assign) AIRGoogleMap *map;
 
 @end

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -31,7 +31,7 @@
 static NSString *const RCTMapViewKey = @"MapView";
 
 
-@interface AIRGoogleMapManager() <GMSMapViewDelegate>
+@interface AIRGoogleMapManager() <GMSMapViewDelegate, GMSIndoorDisplayDelegate>
 {
   BOOL didCallOnMapReady;
 }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -497,7 +497,7 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
       return;
     }
     self.map.onIndoorBuildingFocused(@{
-                                      @"indoorBuilding": @{
+                                      @"IndoorBuilding": @{
                                           @"activeLevelIndex": @0,
                                           @"underground": @false,
                                           @"levels": [[NSMutableArray alloc]init]


### PR DESCRIPTION
Does any other open PR do the same thing?
PR #2189  , it has no return when Indoor Building is out of focus.

What issue is this PR fixing?
Added new events onIndoorBuildingFocused(also return empty array when building is out of focus), onIndoorLevelActivated.
Added command setIndoorActiveLevelIndex
Added new example for Indoor Map.

How did you test this PR?
All new features are for Google Map.
Tested on Android emulator (Nexus 5), iOS Simulator (iPhone X), real Android device (HTC U11), real iOS device (iPhone 6S) by running example.