### PR TITLE
Remove the podspec dependency

### DIFF
--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -15,5 +15,4 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/airbnb/react-native-maps.git" }
   s.source_files  = "lib/ios/AirMaps/**/*.{h,m}"
 
-  s.dependency 'React'
 end


### PR DESCRIPTION
No need for that dependency there.
People already use it in their projects if they need it, and it's only messing up our pod installation if we're not using cocoapods for react.
