### PR TITLE
Smart React util imports

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGMSMarker.h
+++ b/lib/ios/AirGoogleMaps/AIRGMSMarker.h
@@ -6,7 +6,11 @@
 //
 
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 @class AIRGoogleMapMarker;
 

--- a/lib/ios/AirGoogleMaps/AIRGMSPolygon.h
+++ b/lib/ios/AirGoogleMaps/AIRGMSPolygon.h
@@ -6,7 +6,11 @@
 //
 
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 @class AIRGoogleMapPolygon;
 

--- a/lib/ios/AirGoogleMaps/AIRGMSPolyline.h
+++ b/lib/ios/AirGoogleMaps/AIRGMSPolyline.h
@@ -6,7 +6,11 @@
 //
 
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 @class AIRGoogleMapPolyline;
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -6,8 +6,16 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <React/RCTComponent.h>
-#import <React/RCTBridge.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
 #import <GoogleMaps/GoogleMaps.h>
 #import <MapKit/MapKit.h>
 #import "AIRGMSMarker.h"

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -19,8 +19,16 @@
 #import <Google-Maps-iOS-Utils/GMUPoint.h>
 #import <Google-Maps-iOS-Utils/GMUGeometryRenderer.h>
 #import <MapKit/MapKit.h>
-#import <React/UIView+React.h>
-#import <React/RCTBridge.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
 #import "RCTConvert+AirMap.h"
 
 id regionAsJSON(MKCoordinateRegion region) {

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCallout.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCallout.h
@@ -7,7 +7,11 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <React/RCTView.h>
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
 
 @interface AIRGoogleMapCallout : UIView
 @property (nonatomic, assign) BOOL tooltip;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCallout.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCallout.m
@@ -7,9 +7,21 @@
 //
 
 #import "AIRGoogleMapCallout.h"
-#import <React/RCTUtils.h>
-#import <React/RCTView.h>
-#import <React/RCTBridge.h>
+#if __has_include(<React/RCTUtils.h>)
+    #import <React/RCTUtils.h>
+#else
+    #import "RCTUtils.h"
+#endif
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
 
 @implementation AIRGoogleMapCallout
 @end

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.h
@@ -5,7 +5,11 @@
 //  Created by Gil Birman on 9/6/16.
 //
 //
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRGoogleMapCalloutManager : RCTViewManager
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.m
@@ -8,7 +8,11 @@
 
 #import "AIRGoogleMapCalloutManager.h"
 #import "AIRGoogleMapCallout.h"
-#import <React/RCTView.h>
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
 
 @implementation AIRGoogleMapCalloutManager
 RCT_EXPORT_MODULE()

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCircle.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCircle.m
@@ -6,7 +6,11 @@
 #import <UIKit/UIKit.h>
 #import "AIRGoogleMapCircle.h"
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTUtils.h>
+#if __has_include(<React/RCTUtils.h>)
+    #import <React/RCTUtils.h>
+#else
+    #import "RCTUtils.h"
+#endif
 
 @implementation AIRGoogleMapCircle
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCircleManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCircleManager.h
@@ -4,7 +4,11 @@
 //  Created by Nick Italiano on 10/24/16.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRGoogleMapCircleManager : RCTViewManager
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapCircleManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapCircleManager.m
@@ -6,8 +6,16 @@
 
 #import "AIRGoogleMapCircleManager.h"
 #import "AIRGoogleMapCircle.h"
-#import <React/RCTBridge.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 @interface AIRGoogleMapCircleManager()
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
@@ -5,7 +5,11 @@
 //  Created by Gil Birman on 9/1/16.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRGoogleMapManager : RCTViewManager
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -7,14 +7,46 @@
 
 
 #import "AIRGoogleMapManager.h"
-#import <React/RCTViewManager.h>
-#import <React/RCTBridge.h>
-#import <React/RCTUIManager.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/RCTConvert.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTUIManager.h>)
+    #import <React/RCTUIManager.h>
+#else
+    #import "RCTUIManager.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "RCTConvert+GMSMapViewType.h"
 #import "AIRGoogleMap.h"
 #import "AIRMapMarker.h"

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.h
@@ -6,7 +6,11 @@
 //
 
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTBridge.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
 #import "AIRGMSMarker.h"
 #import "AIRGoogleMap.h"
 #import "AIRGoogleMapCallout.h"

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -7,8 +7,16 @@
 
 #import "AIRGoogleMapMarker.h"
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTImageLoader.h>
-#import <React/RCTUtils.h>
+#if __has_include(<React/RCTImageLoader.h>)
+    #import <React/RCTImageLoader.h>
+#else
+    #import "RCTImageLoader.h"
+#endif
+#if __has_include(<React/RCTUtils.h>)
+    #import <React/RCTUtils.h>
+#else
+    #import "RCTUtils.h"
+#endif
 #import "AIRGMSMarker.h"
 #import "AIRGoogleMapCallout.h"
 #import "AIRDummyView.h"

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.h
@@ -5,7 +5,11 @@
 //  Created by Gil Birman on 9/2/16.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRGoogleMapMarkerManager : RCTViewManager
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
@@ -8,7 +8,11 @@
 #import "AIRGoogleMapMarkerManager.h"
 #import "AIRGoogleMapMarker.h"
 #import <MapKit/MapKit.h>
-#import <React/RCTUIManager.h>
+#if __has_include(<React/RCTUIManager.h>)
+    #import <React/RCTUIManager.h>
+#else
+    #import "RCTUIManager.h"
+#endif
 #import "RCTConvert+AirMap.h"
 
 @implementation AIRGoogleMapMarkerManager

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
@@ -6,7 +6,11 @@
 
 #import <Foundation/Foundation.h>
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTBridge.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
 #import "AIRMapCoordinate.h"
 #import "AIRGoogleMap.h"
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
@@ -5,10 +5,26 @@
 
 #import "AIRGoogleMapOverlay.h"
 
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTImageLoader.h>
-#import <React/RCTUtils.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTImageLoader.h>)
+    #import <React/RCTImageLoader.h>
+#else
+    #import "RCTImageLoader.h"
+#endif
+#if __has_include(<React/RCTUtils.h>)
+    #import <React/RCTUtils.h>
+#else
+    #import "RCTUtils.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 @interface AIRGoogleMapOverlay()
   @property (nonatomic, strong, readwrite) UIImage *overlayImage;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlayManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlayManager.h
@@ -4,7 +4,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRGoogleMapOverlayManager : RCTViewManager
 @end

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.h
@@ -5,7 +5,11 @@
 //
 
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTBridge.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
 #import "AIRGMSPolygon.h"
 #import "AIRMapCoordinate.h"
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.h
@@ -4,7 +4,11 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRGoogleMapPolygonManager : RCTViewManager
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
@@ -5,12 +5,36 @@
 //
 #import "AIRGoogleMapPolygonManager.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "RCTConvert+AirMap.h"
 #import "AIRGoogleMapPolygon.h"
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolyline.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolyline.h
@@ -5,7 +5,11 @@
 //
 #import <UIKit/UIKit.h>
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTBridge.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
 #import "AIRGMSPolyline.h"
 #import "AIRMapCoordinate.h"
 #import "AIRGoogleMapMarker.h"

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolyline.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolyline.m
@@ -10,7 +10,11 @@
 #import "AIRGoogleMapMarker.h"
 #import "AIRGoogleMapMarkerManager.h"
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTUtils.h>
+#if __has_include(<React/RCTUtils.h>)
+    #import <React/RCTUtils.h>
+#else
+    #import "RCTUtils.h"
+#endif
 
 @implementation AIRGoogleMapPolyline
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.h
@@ -4,7 +4,11 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRGoogleMapPolylineManager : RCTViewManager
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
@@ -6,12 +6,36 @@
 
 #import "AIRGoogleMapPolylineManager.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "RCTConvert+AirMap.h"
 #import "AIRGoogleMapPolyline.h"
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTileManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapUrlTileManager.h
@@ -4,7 +4,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRGoogleMapUrlTileManager : RCTViewManager
 @end

--- a/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.h
+++ b/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.h
@@ -6,7 +6,11 @@
 
 #import <Foundation/Foundation.h>
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTConvert.h>
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
 
 @interface RCTConvert (GMSMapViewType)
 

--- a/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.m
+++ b/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.m
@@ -6,7 +6,11 @@
 
 #import "RCTConvert+GMSMapViewType.h"
 #import <GoogleMaps/GoogleMaps.h>
-#import <React/RCTConvert.h>
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
 
 @implementation RCTConvert (GMSMapViewType)
   RCT_ENUM_CONVERTER(GMSMapViewType,

--- a/lib/ios/AirMaps/AIRMap.h
+++ b/lib/ios/AirMaps/AIRMap.h
@@ -10,7 +10,11 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTComponent.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
 #import "SMCalloutView.h"
 #import "RCTConvert+AirMap.h"
 

--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -9,8 +9,16 @@
 
 #import "AIRMap.h"
 
-#import <React/RCTEventDispatcher.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMapMarker.h"
 #import "AIRMapPolyline.h"
 #import "AIRMapPolygon.h"

--- a/lib/ios/AirMaps/AIRMapCallout.h
+++ b/lib/ios/AirMaps/AIRMapCallout.h
@@ -4,7 +4,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <React/RCTView.h>
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
 
 
 @interface AIRMapCallout : RCTView

--- a/lib/ios/AirMaps/AIRMapCalloutManager.h
+++ b/lib/ios/AirMaps/AIRMapCalloutManager.h
@@ -3,7 +3,11 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 
 @interface AIRMapCalloutManager : RCTViewManager

--- a/lib/ios/AirMaps/AIRMapCalloutManager.m
+++ b/lib/ios/AirMaps/AIRMapCalloutManager.m
@@ -9,12 +9,36 @@
 
 #import "AIRMapCalloutManager.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMapMarker.h"
 #import "AIRMapCallout.h"
 

--- a/lib/ios/AirMaps/AIRMapCircle.h
+++ b/lib/ios/AirMaps/AIRMapCircle.h
@@ -8,8 +8,16 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTComponent.h>
-#import <React/RCTView.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
 
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"

--- a/lib/ios/AirMaps/AIRMapCircle.m
+++ b/lib/ios/AirMaps/AIRMapCircle.m
@@ -4,7 +4,11 @@
 //
 
 #import "AIRMapCircle.h"
-#import <React/UIView+React.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 
 @implementation AIRMapCircle {

--- a/lib/ios/AirMaps/AIRMapCircleManager.h
+++ b/lib/ios/AirMaps/AIRMapCircleManager.h
@@ -3,7 +3,11 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 
 @interface AIRMapCircleManager : RCTViewManager

--- a/lib/ios/AirMaps/AIRMapCircleManager.m
+++ b/lib/ios/AirMaps/AIRMapCircleManager.m
@@ -9,12 +9,36 @@
 
 #import "AIRMapCircleManager.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMapMarker.h"
 #import "AIRMapCircle.h"
 

--- a/lib/ios/AirMaps/AIRMapLocalTile.h
+++ b/lib/ios/AirMaps/AIRMapLocalTile.h
@@ -10,8 +10,16 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTComponent.h>
-#import <React/RCTView.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
 #import "RCTConvert+AirMap.h"

--- a/lib/ios/AirMaps/AIRMapLocalTile.m
+++ b/lib/ios/AirMaps/AIRMapLocalTile.m
@@ -7,7 +7,11 @@
 //
 
 #import "AIRMapLocalTile.h"
-#import <React/UIView+React.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMapLocalTileOverlay.h"
 
 @implementation AIRMapLocalTile {

--- a/lib/ios/AirMaps/AIRMapLocalTileManager.h
+++ b/lib/ios/AirMaps/AIRMapLocalTileManager.h
@@ -6,7 +6,11 @@
 //  Copyright © 2017 Christopher. All rights reserved.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRMapLocalTileManager : RCTViewManager
 

--- a/lib/ios/AirMaps/AIRMapLocalTileManager.m
+++ b/lib/ios/AirMaps/AIRMapLocalTileManager.m
@@ -6,12 +6,36 @@
 //  Copyright © 2017 Christopher. All rights reserved.
 //
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMapMarker.h"
 #import "AIRMapLocalTile.h"
 

--- a/lib/ios/AirMaps/AIRMapManager.h
+++ b/lib/ios/AirMaps/AIRMapManager.h
@@ -7,7 +7,11 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 #import "AIRMap.h"
 
 #define MERCATOR_RADIUS 85445659.44705395

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -9,13 +9,41 @@
 
 #import "AIRMapManager.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTUIManager.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTUIManager.h>)
+    #import <React/RCTUIManager.h>
+#else
+    #import "RCTUIManager.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMap.h"
 #import "AIRMapMarker.h"
 #import "AIRMapPolyline.h"

--- a/lib/ios/AirMaps/AIRMapMarker.h
+++ b/lib/ios/AirMaps/AIRMapMarker.h
@@ -13,7 +13,11 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTComponent.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
 #import "AIRMap.h"
 #import "SMCalloutView.h"
 #import "RCTConvert+AirMap.h"

--- a/lib/ios/AirMaps/AIRMapMarker.m
+++ b/lib/ios/AirMaps/AIRMapMarker.m
@@ -9,11 +9,31 @@
 
 #import "AIRMapMarker.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTImageLoader.h>
-#import <React/RCTUtils.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTImageLoader.h>)
+    #import <React/RCTImageLoader.h>
+#else
+    #import "RCTImageLoader.h"
+#endif
+#if __has_include(<React/RCTUtils.h>)
+    #import <React/RCTUtils.h>
+#else
+    #import "RCTUtils.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
 

--- a/lib/ios/AirMaps/AIRMapMarkerManager.h
+++ b/lib/ios/AirMaps/AIRMapMarkerManager.h
@@ -7,7 +7,11 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRMapMarkerManager : RCTViewManager
 

--- a/lib/ios/AirMaps/AIRMapMarkerManager.m
+++ b/lib/ios/AirMaps/AIRMapMarkerManager.m
@@ -9,9 +9,21 @@
 
 #import "AIRMapMarkerManager.h"
 
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTUIManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTUIManager.h>)
+    #import <React/RCTUIManager.h>
+#else
+    #import "RCTUIManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMapMarker.h"
 
 @interface AIRMapMarkerManager () <MKMapViewDelegate>

--- a/lib/ios/AirMaps/AIRMapOverlay.h
+++ b/lib/ios/AirMaps/AIRMapOverlay.h
@@ -4,7 +4,11 @@
 #import <UIKit/UIKit.h>
 
 #import "RCTConvert+AirMap.h"
-#import <React/RCTComponent.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
 #import "AIRMap.h"
 #import "AIRMapOverlayRenderer.h"
 

--- a/lib/ios/AirMaps/AIRMapOverlay.m
+++ b/lib/ios/AirMaps/AIRMapOverlay.m
@@ -1,10 +1,30 @@
 #import "AIRMapOverlay.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTImageLoader.h>
-#import <React/RCTUtils.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTImageLoader.h>)
+    #import <React/RCTImageLoader.h>
+#else
+    #import "RCTImageLoader.h"
+#endif
+#if __has_include(<React/RCTUtils.h>)
+    #import <React/RCTUtils.h>
+#else
+    #import "RCTUtils.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 @interface AIRMapOverlay()
 @property (nonatomic, strong, readwrite) UIImage *overlayImage;

--- a/lib/ios/AirMaps/AIRMapOverlayManager.h
+++ b/lib/ios/AirMaps/AIRMapOverlayManager.h
@@ -1,4 +1,8 @@
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRMapOverlayManager : RCTViewManager
 

--- a/lib/ios/AirMaps/AIRMapOverlayManager.m
+++ b/lib/ios/AirMaps/AIRMapOverlayManager.m
@@ -1,8 +1,20 @@
 #import "AIRMapOverlayManager.h"
 
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTUIManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTUIManager.h>)
+    #import <React/RCTUIManager.h>
+#else
+    #import "RCTUIManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMapOverlay.h"
 
 @interface AIRMapOverlayManager () <MKMapViewDelegate>

--- a/lib/ios/AirMaps/AIRMapPolygon.h
+++ b/lib/ios/AirMaps/AIRMapPolygon.h
@@ -8,8 +8,16 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTComponent.h>
-#import <React/RCTView.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
 #import "RCTConvert+AirMap.h"

--- a/lib/ios/AirMaps/AIRMapPolygon.m
+++ b/lib/ios/AirMaps/AIRMapPolygon.m
@@ -4,7 +4,11 @@
 //
 
 #import "AIRMapPolygon.h"
-#import <React/UIView+React.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 
 @implementation AIRMapPolygon {

--- a/lib/ios/AirMaps/AIRMapPolygonManager.h
+++ b/lib/ios/AirMaps/AIRMapPolygonManager.h
@@ -3,7 +3,11 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 
 @interface AIRMapPolygonManager : RCTViewManager

--- a/lib/ios/AirMaps/AIRMapPolygonManager.m
+++ b/lib/ios/AirMaps/AIRMapPolygonManager.m
@@ -9,12 +9,36 @@
 
 #import "AIRMapPolygonManager.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "RCTConvert+AirMap.h"
 #import "AIRMapMarker.h"
 #import "AIRMapPolygon.h"

--- a/lib/ios/AirMaps/AIRMapPolyline.h
+++ b/lib/ios/AirMaps/AIRMapPolyline.h
@@ -8,8 +8,16 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTComponent.h>
-#import <React/RCTView.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
 #import "RCTConvert+AirMap.h"

--- a/lib/ios/AirMaps/AIRMapPolyline.m
+++ b/lib/ios/AirMaps/AIRMapPolyline.m
@@ -5,7 +5,11 @@
 
 #import "AIRMapPolyline.h"
 #import "AIRMapPolylineRenderer.h"
-#import <React/UIView+React.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 
 @implementation AIRMapPolyline {

--- a/lib/ios/AirMaps/AIRMapPolylineManager.h
+++ b/lib/ios/AirMaps/AIRMapPolylineManager.h
@@ -3,7 +3,11 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 
 @interface AIRMapPolylineManager : RCTViewManager

--- a/lib/ios/AirMaps/AIRMapPolylineManager.m
+++ b/lib/ios/AirMaps/AIRMapPolylineManager.m
@@ -9,12 +9,36 @@
 
 #import "AIRMapPolylineManager.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "RCTConvert+AirMap.h"
 #import "AIRMapMarker.h"
 #import "AIRMapPolyline.h"

--- a/lib/ios/AirMaps/AIRMapUrlTile.h
+++ b/lib/ios/AirMaps/AIRMapUrlTile.h
@@ -10,8 +10,16 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTComponent.h>
-#import <React/RCTView.h>
+#if __has_include(<React/RCTComponent.h>)
+    #import <React/RCTComponent.h>
+#else
+    #import "RCTComponent.h"
+#endif
+#if __has_include(<React/RCTView.h>)
+    #import <React/RCTView.h>
+#else
+    #import "RCTView.h"
+#endif
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
 #import "RCTConvert+AirMap.h"

--- a/lib/ios/AirMaps/AIRMapUrlTile.m
+++ b/lib/ios/AirMaps/AIRMapUrlTile.m
@@ -7,7 +7,11 @@
 //
 
 #import "AIRMapUrlTile.h"
-#import <React/UIView+React.h>
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 
 @implementation AIRMapUrlTile {
     BOOL _urlTemplateSet;

--- a/lib/ios/AirMaps/AIRMapUrlTileManager.h
+++ b/lib/ios/AirMaps/AIRMapUrlTileManager.h
@@ -7,7 +7,11 @@
 //
 
 
-#import <React/RCTViewManager.h>
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
 
 @interface AIRMapUrlTileManager : RCTViewManager
 

--- a/lib/ios/AirMaps/AIRMapUrlTileManager.m
+++ b/lib/ios/AirMaps/AIRMapUrlTileManager.m
@@ -6,12 +6,36 @@
 //  Copyright © 2016. All rights reserved.
 //
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTViewManager.h>
-#import <React/UIView+React.h>
+#if __has_include(<React/RCTBridge.h>)
+    #import <React/RCTBridge.h>
+#else
+    #import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
+#if __has_include(<React/RCTEventDispatcher.h>)
+    #import <React/RCTEventDispatcher.h>
+#else
+    #import "RCTEventDispatcher.h"
+#endif
+#if __has_include(<React/RCTViewManager.h>)
+    #import <React/RCTViewManager.h>
+#else
+    #import "RCTViewManager.h"
+#endif
+#if __has_include(<React/UIView+React.h>)
+    #import <React/UIView+React.h>
+#else
+    #import "UIView+React.h"
+#endif
 #import "AIRMapMarker.h"
 #import "AIRMapUrlTile.h"
 

--- a/lib/ios/AirMaps/RCTConvert+AirMap.h
+++ b/lib/ios/AirMaps/RCTConvert+AirMap.h
@@ -5,7 +5,11 @@
 
 #import <CoreLocation/CoreLocation.h>
 #import <MapKit/MapKit.h>
-#import <React/RCTConvert.h>
+#if __has_include(<React/RCTConvert.h>)
+    #import <React/RCTConvert.h>
+#else
+    #import "RCTConvert.h"
+#endif
 
 @interface RCTConvert (AirMap)
 

--- a/lib/ios/AirMaps/RCTConvert+AirMap.m
+++ b/lib/ios/AirMaps/RCTConvert+AirMap.m
@@ -5,7 +5,11 @@
 
 #import "RCTConvert+AirMap.h"
 
-#import <React/RCTConvert+CoreLocation.h>
+#if __has_include(<React/RCTConvert+CoreLocation.h>)
+    #import <React/RCTConvert+CoreLocation.h>
+#else
+    #import "RCTConvert+CoreLocation.h"
+#endif
 #import "AIRMapCoordinate.h"
 
 @implementation RCTConvert (AirMap)

--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "lib/ios/AirGoogleMaps/**/*.{h,m}"
   s.compiler_flags = '-fno-modules'
 
-  s.dependency 'React'
   s.dependency 'GoogleMaps', '2.5.0'
   s.dependency 'Google-Maps-iOS-Utils', '2.1.0'
 end

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -15,5 +15,4 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/airbnb/react-native-maps.git" }
   s.source_files  = "lib/ios/AirMaps/**/*.{h,m}"
 
-  s.dependency 'React'
 end


### PR DESCRIPTION
### What issue is this PR fixing?
This PR changes the way React components/utils/objects are imported so that imports work both with `react-native link` AND `cocoapods` React embedded projects.

### How did you test this PR?

Tested it on my react-native link project and it works.
