### PR TITLE
Implemented `tracksViewChanges` for Android

### DIFF
--- a/docs/marker.md
+++ b/docs/marker.md
@@ -17,7 +17,7 @@
 | `identifier` | `String` |  | An identifier used to reference this marker at a later date.
 | `rotation` | `Float` | 0 | A float number indicating marker's rotation angle, in degrees.
 | `draggable` | `<null>` |  | This is a non-value based prop. Adding this allows the marker to be draggable (re-positioned).
-| `tracksViewChanges` | `Boolean` | true | Sets whether this marker should track view changes. It's recommended to turn it off whenever it's possible to improve custom marker performance. **Note**: iOS Google Maps only.
+| `tracksViewChanges` | `Boolean` | true | Sets whether this marker should track view changes. It's recommended to turn it off whenever it's possible to improve custom marker performance.
 | `tracksInfoWindowChanges` | `Boolean` | false | Sets whether this marker should track view changes in info window. Enabling it will let marker change content of info window after first render pass, but will lead to decreased performance, so it's recommended to disable it whenever you don't need it. **Note**: iOS Google Maps only.
 | `stopPropagation` | `Boolean` | false | Sets whether this marker should propagate `onPress` events. Enabling it will stop the parent `MapView`'s `onPress` from being called. **Note**: iOS only. Android does not propagate `onPress` events. See [#1132](https://github.com/react-community/react-native-maps/issues/1132) for more information.
 | `opacity` | `Float` | 1.0 | The marker's opacity between 0.0 and 1.0.

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/ViewChangesTracker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/ViewChangesTracker.java
@@ -1,0 +1,75 @@
+package com.airbnb.android.react.maps;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.LinkedList;
+
+public class ViewChangesTracker {
+
+  private static ViewChangesTracker instance;
+  private Handler handler;
+  private LinkedList<AirMapMarker> markers = new LinkedList<>();
+  private boolean hasScheduledFrame = false;
+  private Runnable updateRunnable;
+  private final long fps = 40;
+
+  private ViewChangesTracker() {
+    handler = new Handler(Looper.myLooper());
+    updateRunnable = new Runnable() {
+      @Override
+      public void run() {
+        hasScheduledFrame = false;
+        update();
+
+        if (markers.size() > 0) {
+          handler.postDelayed(updateRunnable, fps);
+        }
+      }
+    };
+  }
+
+  static ViewChangesTracker getInstance() {
+    if (instance == null) {
+      synchronized (ViewChangesTracker.class) {
+        instance = new ViewChangesTracker();
+      }
+    }
+
+    return instance;
+  }
+
+  public void addMarker(AirMapMarker marker) {
+    markers.add(marker);
+
+    if (!hasScheduledFrame) {
+      hasScheduledFrame = true;
+      handler.postDelayed(updateRunnable, fps);
+    }
+  }
+
+  public void removeMarker(AirMapMarker marker) {
+    markers.remove(marker);
+  }
+
+  public boolean containsMarker(AirMapMarker marker) {
+    return markers.contains(marker);
+  }
+
+  private LinkedList<AirMapMarker> markersToRemove = new LinkedList<>();
+
+  public void update() {
+    for (AirMapMarker marker : markers) {
+      if (!marker.updateCustomMarkerIcon()) {
+        markersToRemove.add(marker);
+      }
+    }
+
+    // Remove markers that are not active anymore
+    if (markersToRemove.size() > 0) {
+      markers.removeAll(markersToRemove);
+      markersToRemove.clear();;
+    }
+  }
+
+}


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

This is related to the following issues:
#1870 #2105 #2048 #2082

### How did you test this PR?

In my own project, with a progressing pie animation inside the marker.
I've also made sure that tracking stops when the marker is removed from the map etc.

### Some background and explanation

iOS has the `tracksViewChanges` property which causes re-renders of the markers all the time, and slows down performance of the map greatly. 
Still, it is very handy especially given the async nature of React.
As many times the first images cached is of a blank component, it is very useful to use `tracksViewChanges=true` and then set it to `false` when `componentDidUpdate` is hit.

Another issue is loading images. Assuming the image loading issue will be fixed one day - we will still want `tracksViewChanges` and disabled that when `onLoadEnd` hits.
We could even start with it as a false value, and then turn it on and off when the loading is done.

Now some people use several hacks for the image issue on Android, like actual changes to Fesco code and usage of SVG images inside the Marker. But in those cases it is still slightly unstable and sometimes blank - but just because of the asyncronisity of react. This will also solve that.


I've set a default fps of 25, which seemed reasonable to me. But based on user feedback this could be easily adjusted.