### PR TITLE
Let onVisibilityChanged() be called on children (mainly fixes Image issues)

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.PorterDuff;
+import android.graphics.Rect;
 import android.os.Build;
 import android.support.v4.view.GestureDetectorCompat;
 import android.support.v4.view.MotionEventCompat;
@@ -29,6 +30,7 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -100,6 +102,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   private final ThemedReactContext context;
   private final EventDispatcher eventDispatcher;
 
+  private ViewAttacherGroup attacherGroup;
+
   private static boolean contextHasBug(Context context) {
     return context == null ||
         context.getResources() == null ||
@@ -169,6 +173,24 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     });
 
     eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+
+    // Set up a parent view for triggering visibility in subviews that depend on it.
+    // Mainly ReactImageView depends on Fresco which depends on onVisibilityChanged() event
+    attacherGroup = new ViewAttacherGroup(context);
+    LayoutParams attacherLayoutParams = new LayoutParams(0, 0);
+    attacherLayoutParams.width = 0;
+    attacherLayoutParams.height = 0;
+    attacherLayoutParams.leftMargin = 99999999;
+    attacherLayoutParams.topMargin = 99999999;
+    attacherGroup.setLayoutParams(attacherLayoutParams);
+    attacherGroup.setVisibility(VISIBLE);
+    attacherGroup.setAlpha(0.0f);
+    attacherGroup.setRemoveClippedSubviews(false);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      attacherGroup.setClipBounds(new Rect(0, 0, 0, 0));
+    }
+    attacherGroup.setOverflow(ViewProps.HIDDEN);
+    addView(attacherGroup);
   }
 
   @Override
@@ -517,6 +539,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       AirMapMarker annotation = (AirMapMarker) child;
       annotation.addToMap(map);
       features.add(index, annotation);
+
+      int visibility = annotation.getVisibility();
+      annotation.setVisibility(INVISIBLE);
+      attacherGroup.addView(annotation);
+      annotation.setVisibility(visibility);
+
       Marker marker = (Marker) annotation.getFeature();
       markerMap.put(marker, annotation);
     } else if (child instanceof AirMapPolyline) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/ViewAttacherGroup.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/ViewAttacherGroup.java
@@ -1,0 +1,18 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+
+import com.facebook.react.views.view.ReactViewGroup;
+
+public class ViewAttacherGroup extends ReactViewGroup {
+
+  public ViewAttacherGroup(Context context) {
+    super(context);
+  }
+
+  // This should make it more performant, avoid trying to hard to overlap layers with opacity.
+  @Override
+  public boolean hasOverlappingRendering() {
+    return false;
+  }
+}


### PR DESCRIPTION
### Does any other open PR do the same thing?

Nope.

### What issue is this PR fixing?

This is related to the following issues:
#1870 #2105 #2048 

The REAL problem with displaying images inside the markers in Android, is not a bug in Fresco as claimed in some issues. It's that Fresco depends on the `onVisibilityChanged(...)` event to be called. And that's a protected method. And is propagated by `dispatchVisibilityChanged(...)` to the whole subview hierarchy. `dispatchVisibilityChanged` is protected too. And it depends on `mAttachInfo` etc.
So fiddling with Reflection is not an option as it counts on too many private stuff to not change in Android's core.

The solution I propose here is having a semi-invisible ViewGroup and add the markers' views to it, so it is properly "visible".
I'm calling it semi-invisible because setting visibility to INVISIBLE/GONE will again prevent the subviews from getting visibility events. What I did is set it to zero size, offscreen, clipping, and 0 opacity. So basically doing everything to avoid it trying to draw, but letting the events pass through.

For me, this fixes the issue - together with #2477 

### How did you test this PR?

Real life project with animatable Markers.
