### PR TITLE
Fix peer dependencies warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "mapkit"
   ],
   "peerDependencies": {
-    "react": "^16.0",
-    "react-native": "^0.51 || ^0.52 || ^0.53 || ^0.54 || ^0.55",
+    "react": ">= 16.0 || < 17.0",
+    "react-native": ">= 0.51",
     "prop-types": "^15.0 || ^16.0"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "gitbook-cli": "^2.3.0",
     "lodash": "^4.17.2",
     "prop-types": "^15.5.10",
-    "react": "^16.3.0-alpha.1",
+    "react": "^16.3.2",
     "react-native": "^0.54"
   },
   "rnpm": {


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No.

### What issue is this PR fixing?

This PR will fix peer dependencies warnings when you run `npm install` on the projects which are using React Native 0.56.0(or later). This relates to #2332 .

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

in my project,

- remove react-native-maps from package.json.
- remove `node_modules`
- run `npm install` again
- run `npm install <relative path to react-native-maps> --save`
- confirm warning messages related to react-native don't appear.

However, it doesn't solve the warning around @babel-core@7.0.0-beta.38(required by @babel/plugin-check-constants@7.0.0-beta.38).

<!--
Thanks for your contribution :)
-->
