### PR TITLE
"hidden" instead of ViewProps.HIDDEN until RN 0.57 is the base version

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -189,7 +189,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       attacherGroup.setClipBounds(new Rect(0, 0, 0, 0));
     }
-    attacherGroup.setOverflow(ViewProps.HIDDEN);
+    attacherGroup.setOverflow("hidden"); // Move to ViewProps.HIDDEN when RN 0.57 is the base version
     addView(attacherGroup);
   }
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

https://github.com/react-community/react-native-maps/pull/2478#issuecomment-420381739
