### PR TITLE
[iOS] Fixed issue that app will crash after trigger  Marker onDragEnd

### DIFF
--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -37,7 +37,9 @@ static NSString *const RCTMapViewKey = @"MapView";
 
 @end
 
-@implementation AIRMapManager
+@implementation AIRMapManager{
+   BOOL _hasObeserver;
+}
   
 RCT_EXPORT_MODULE()
 
@@ -704,11 +706,12 @@ static int kDragCenterContext;
         if (mapView.onMarkerDragEnd) mapView.onMarkerDragEnd(event);
         if (marker.onDragEnd) marker.onDragEnd(event);
 
-        [view removeObserver:self forKeyPath:@"center"];
+       if(_hasObeserver) [view removeObserver:self forKeyPath:@"center"];
+        _hasObeserver = NO;
     } else if (newState == MKAnnotationViewDragStateStarting) {
         // MapKit doesn't emit continuous drag events. To get around this, we are going to use KVO.
         [view addObserver:self forKeyPath:@"center" options:NSKeyValueObservingOptionNew context:&kDragCenterContext];
-
+        _hasObeserver = YES;
         if (mapView.onMarkerDragStart) mapView.onMarkerDragStart(event);
         if (marker.onDragStart) marker.onDragStart(event);
     }


### PR DESCRIPTION
Does any other open PR do the same thing?
No

What issue is this PR fixing?
When drag the Marker on map, sometimes app will crash when onDragEnd.

How did you test this PR?
Tested on iOS simulator with iOS11.4, iOS 12.0
iPhone6 12.0
