### PR TITLE
Fix for “The specified child already has a parent”

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -542,6 +542,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       int visibility = annotation.getVisibility();
       annotation.setVisibility(INVISIBLE);
 
+      // Remove from a view group if already present, prevent "specified child
+      // already had a parent" error.
+      ViewGroup annotationParent = (ViewGroup)annotation.getParent();
+      if (annotationParent != null) {
+        annotationParent.removeView(annotation);
+      }
+
       // Add to the parent group
       attacherGroup.addView(annotation);
 


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No.

### What issue is this PR fixing?

I haven't created an issue for it, but seems to be the same issue found here:
https://github.com/react-community/react-native-maps/issues/2447

Error it fixes is the following, which for me personally occurred when re-rendering with the map with a partially different set of Markers.
For performance reasons in my project on render only markers that are within the specified region are returned with render, with the map re-rendering markers using `onRegionChangeComplete`. With small changes it is generally fine however I found when animating a region change where a lot of markers change this crash would occur.
This simple change in the java code fixed the issue for me.
![screenshot_20181011-105356_dusk](https://user-images.githubusercontent.com/356181/46797736-e13c5600-cd47-11e8-8cac-db29e83215dd.jpg)

(please link the issue here)

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

I only have this issue on Android, and I could consistently replicate the crash on a suite of android test devices. After the fix it was easy to confirm that it fixed the issue for me. Also the code snippet is pretty harmless and contained, checks for null and should not introduce any crashes.

<!--
Thanks for your contribution :)
-->
