### PR TITLE
Provide a camera system

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -7,6 +7,8 @@
 | `provider` | `string` |  | The map framework to use. <br/><br/>Either `"google"` for GoogleMaps, otherwise `null` or `undefined` to use the native map framework (`MapKit` in iOS and `GoogleMaps` in android).
 | `region` | `Region` |  | The region to be displayed by the map. <br/><br/>The region is defined by the center coordinates and the span of coordinates to display.
 | `initialRegion` | `Region` |  | The initial region to be displayed by the map.  Use this prop instead of `region` only if you don't want to control the viewport of the map besides the initial region.<br/><br/> Changing this prop after the component has mounted will not result in a region change.<br/><br/> This is similar to the `initialValue` prop of a text input.
+| `camera` | `Camera` |  | The camera view the map should display. If you use this, the `region` property is ignored.
+| `initialCamera` | `Camera` |  | Like `initialRegion`, use this prop instead of `camera` only if you don't want to control the viewport of the map besides the initial camera setting.<br/><br/> Changing this prop after the component has mounted will not result in a region change.<br/><br/> This is similar to the `initialValue` prop of a text input.
 | `mapPadding` | `EdgePadding` |  | Adds custom padding to each side of the map. Useful when map elements/markers are obscured. **Note** Google Maps only.
 | `paddingAdjustmentBehavior` | 'always'\|'automatic'\|'never' | 'never' | Indicates how/when to affect padding with safe area insets (`GoogleMaps` in iOS only)
 | `liteMode` | `Boolean` | `false` | Enable lite mode. **Note**: Android only.
@@ -71,11 +73,14 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 
 | Method Name | Arguments | Notes
 |---|---|---|
-| `animateToNavigation` | `location: LatLng`, `bearing: Number`, `angle: Number`, `duration: Number` |
+| `getCamera` | | Returns a `Camera` structure indicating the current camera configuration.
+| `animateCamera` | `camera: Camera`, `{ duration: Number }` | Animate the camera to a new view. You can pass a partial camera object here; any property not given will remain unmodified.
+| `setCamera` | `camera: Camera`, `{ duration: Number }` | Like `animateCamera`, but sets the new view instantly, without an animation.
 | `animateToRegion` | `region: Region`, `duration: Number` |
-| `animateToCoordinate` | `coordinate: LatLng`, `duration: Number` |
-| `animateToBearing` | `bearing: Number`, `duration: Number` |
-| `animateToViewingAngle` | `angle: Number`, `duration: Number` |
+| `animateToNavigation` | `location: LatLng`, `bearing: Number`, `angle: Number`, `duration: Number` | Deprecated. Use `animateCamera` instead.
+| `animateToCoordinate` | `coordinate: LatLng`, `duration: Number` | Deprecated. Use `animateCamera` instead.
+| `animateToBearing` | `bearing: Number`, `duration: Number` | Deprecated. Use `animateCamera` instead.
+| `animateToViewingAngle` | `angle: Number`, `duration: Number` | Deprecated. Use `animateCamera` instead.
 | `getMapBoundaries` | | `Promise<{northEast: LatLng, southWest: LatLng}>`
 | `setMapBoundaries` | `northEast: LatLng`, `southWest: LatLng` | `GoogleMaps only`
 | `setIndoorActiveLevelIndex` | `levelIndex: Number` |
@@ -97,6 +102,26 @@ type Region {
   longitudeDelta: Number,
 }
 ```
+
+```
+type Camera = {
+    center: {
+       latitude: number,
+       longitude: number,
+   },
+   pitch: number,
+   heading: number
+
+   // Only on iOS MapKit, in meters. The property is ignored by Google Maps.
+   altitude: number.
+
+   // Only when using Google Maps.
+   zoom: number
+}
+```
+
+Note that when using the `Camera`, MapKit on iOS and Google Maps differ in how the height is specified. For a cross-platform app, it is necessary
+to specify both the zoom level and the altitude separately.
 
 ```
 type LatLng {

--- a/example/App.js
+++ b/example/App.js
@@ -44,6 +44,7 @@ import ImageOverlayWithURL from './examples/ImageOverlayWithURL';
 import AnimatedNavigation from './examples/AnimatedNavigation';
 import OnPoiClick from './examples/OnPoiClick';
 import IndoorMap from './examples/IndoorMap';
+import CameraControl from './examples/CameraControl';
 
 const IOS = Platform.OS === 'ios';
 const ANDROID = Platform.OS === 'android';
@@ -166,6 +167,7 @@ class App extends React.Component {
       [AnimatedNavigation, 'Animated Map Navigation', true],
       [OnPoiClick, 'On Poi Click', true],
       [IndoorMap, 'Indoor Map', true],
+      [CameraControl, 'CameraControl', true],
     ]
     // Filter out examples that are not yet supported for Google Maps on iOS.
     .filter(example => ANDROID || (IOS && (example[2] || !this.state.useGoogleMaps)))

--- a/example/examples/AnimatedNavigation.js
+++ b/example/examples/AnimatedNavigation.js
@@ -43,7 +43,7 @@ export default class NavigationMap extends Component {
   updateMap() {
     const { curPos, prevPos, curAng } = this.state;
     const curRot = this.getRotation(prevPos, curPos);
-    this.map.animateToNavigation(curPos, curRot, curAng);
+    this.map.animateCamera({ heading: curRot, center: curPos, pitch: curAng });
   }
 
   render() {

--- a/example/examples/CameraControl.js
+++ b/example/examples/CameraControl.js
@@ -2,25 +2,15 @@ import React from 'react';
 import {
   StyleSheet,
   View,
-  Dimensions,
   TouchableOpacity,
   Text,
-  Alert
+  Alert,
 } from 'react-native';
 
-import MapView from 'react-native-maps';
+import MapView, { ProviderPropType } from 'react-native-maps';
 
-const {width, height} = Dimensions.get('window');
-
-const ASPECT_RATIO = width / height;
 const LATITUDE = 37.78825;
 const LONGITUDE = -122.4324;
-const LATITUDE_DELTA = 0.0922;
-const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
-const SPACE = 0.01;
-
-
-const DEFAULT_PADDING = {top: 40, right: 40, bottom: 40, left: 40};
 
 
 class CameraControl extends React.Component {
@@ -30,10 +20,10 @@ class CameraControl extends React.Component {
       'Current camera',
       JSON.stringify(camera),
       [
-        {text: 'OK'},
+        { text: 'OK' },
       ],
       { cancelable: true }
-    )
+    );
   }
 
   async setCamera() {
@@ -41,18 +31,18 @@ class CameraControl extends React.Component {
     // Note that we do not have to pass a full camera object to setCamera().
     // Similar to setState(), we can pass only the properties you like to change.
     this.map.setCamera({
-      heading: camera.heading + 10
+      heading: camera.heading + 10,
     });
   }
 
   async animateCamera() {
     const camera = await this.map.getCamera();
-    camera.heading = camera.heading + 40;
-    camera.pitch = camera.pitch + 10;
-    camera.altitude = camera.altitude + 1000;
-    camera.zoom = camera.zoom + 1;
-    camera.center.latitude = camera.center.latitude + 0.5;
-    this.map.animateCamera(camera, {duration: 2000});
+    camera.heading += 40;
+    camera.pitch += 10;
+    camera.altitude += 1000;
+    camera.zoom -= 1;
+    camera.center.latitude += 0.5;
+    this.map.animateCamera(camera, { duration: 2000 });
   }
 
   render() {
@@ -72,10 +62,9 @@ class CameraControl extends React.Component {
             pitch: 45,
             heading: 90,
             altitude: 1000,
-            zoom: 10
+            zoom: 10,
           }}
-        >
-        </MapView>
+        />
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             onPress={() => this.getCamera()}
@@ -100,6 +89,11 @@ class CameraControl extends React.Component {
     );
   }
 }
+
+CameraControl.propTypes = {
+  provider: ProviderPropType,
+};
+
 
 const styles = StyleSheet.create({
   container: {

--- a/example/examples/CameraControl.js
+++ b/example/examples/CameraControl.js
@@ -1,0 +1,132 @@
+import React from 'react';
+import {
+  StyleSheet,
+  View,
+  Dimensions,
+  TouchableOpacity,
+  Text,
+  Alert
+} from 'react-native';
+
+import MapView from 'react-native-maps';
+
+const {width, height} = Dimensions.get('window');
+
+const ASPECT_RATIO = width / height;
+const LATITUDE = 37.78825;
+const LONGITUDE = -122.4324;
+const LATITUDE_DELTA = 0.0922;
+const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+const SPACE = 0.01;
+
+
+const DEFAULT_PADDING = {top: 40, right: 40, bottom: 40, left: 40};
+
+
+class CameraControl extends React.Component {
+  async getCamera() {
+    const camera = await this.map.getCamera();
+    Alert.alert(
+      'Current camera',
+      JSON.stringify(camera),
+      [
+        {text: 'OK'},
+      ],
+      { cancelable: true }
+    )
+  }
+
+  async setCamera() {
+    const camera = await this.map.getCamera();
+    // Note that we do not have to pass a full camera object to setCamera().
+    // Similar to setState(), we can pass only the properties you like to change.
+    this.map.setCamera({
+      heading: camera.heading + 10
+    });
+  }
+
+  async animateCamera() {
+    const camera = await this.map.getCamera();
+    camera.heading = camera.heading + 40;
+    camera.pitch = camera.pitch + 10;
+    camera.altitude = camera.altitude + 1000;
+    camera.zoom = camera.zoom + 1;
+    camera.center.latitude = camera.center.latitude + 0.5;
+    this.map.animateCamera(camera, {duration: 2000});
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView
+          provider={this.props.provider}
+          ref={ref => {
+            this.map = ref;
+          }}
+          style={styles.map}
+          initialCamera={{
+            center: {
+              latitude: LATITUDE,
+              longitude: LONGITUDE,
+            },
+            pitch: 45,
+            heading: 90,
+            altitude: 1000,
+            zoom: 10
+          }}
+        >
+        </MapView>
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity
+            onPress={() => this.getCamera()}
+            style={[styles.bubble, styles.button]}
+          >
+            <Text>Get current camera</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => this.setCamera()}
+            style={[styles.bubble, styles.button]}
+          >
+            <Text>Set Camera</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => this.animateCamera()}
+            style={[styles.bubble, styles.button]}
+          >
+            <Text>Animate Camera</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  bubble: {
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 20,
+  },
+  button: {
+    marginTop: 12,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    marginHorizontal: 10,
+  },
+  buttonContainer: {
+    flexDirection: 'column',
+    marginVertical: 20,
+    backgroundColor: 'transparent',
+  },
+});
+
+export default CameraControl;

--- a/example/examples/DisplayLatLng.js
+++ b/example/examples/DisplayLatLng.js
@@ -44,15 +44,15 @@ class DisplayLatLng extends React.Component {
   }
 
   animateRandomCoordinate() {
-    this.map.animateToCoordinate(this.randomCoordinate());
+    this.map.animateCamera({ center: this.randomCoordinate() });
   }
 
   animateToRandomBearing() {
-    this.map.animateToBearing(this.getRandomFloat(-360, 360));
+    this.map.animateCamera({ heading: this.getRandomFloat(-360, 360) });
   }
 
   animateToRandomViewingAngle() {
-    this.map.animateToViewingAngle(this.getRandomFloat(0, 90));
+    this.map.animateCamera({ pitch: this.getRandomFloat(0, 90) });
   }
 
   getRandomFloat(min, max) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,14 @@ declare module "react-native-maps" {
         longitude: number;
     }
 
+    export interface Camera {
+        center: LatLng;
+        heading: number;
+        pitch: number;
+        zoom: number;
+        altitude: number;
+    }
+
     export interface Point {
         x: number;
         y: number;
@@ -186,6 +194,8 @@ declare module "react-native-maps" {
         mapType?: MapTypes;
         region?: Region;
         initialRegion?: Region;
+        camera?: Camera;
+        initialCamera?: Camera;
         liteMode?: boolean;
         mapPadding?: EdgePadding;
         maxDelta?: number;
@@ -215,6 +225,9 @@ declare module "react-native-maps" {
     }
 
     export default class MapView extends React.Component<MapViewProps, any> {
+        getCamera(): Promise<Camera>;
+        setCamera(camera: Partial<Camera>);
+        animateCamera(camera: Partial<Camera>, opts?: {duration?: number});
         animateToNavigation(location: LatLng, bearing: number, angle: number, duration?: number): void;
         animateToRegion(region: Region, duration?: number): void;
         animateToCoordinate(latLng: LatLng, duration?: number): void;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -411,8 +411,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     map.put(k6, v6);
     map.put(k7, v7);
     map.put(k8, v8);
-    map.put(k8, v8);
-    map.put(k8, v8);
+    map.put(k9, v9);
+    map.put(k10, v10);
     return map;
   }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -88,6 +88,16 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     view.setInitialRegion(initialRegion);
   }
 
+  @ReactProp(name = "camera")
+  public void setCamera(AirMapView view, ReadableMap camera) {
+    view.setCamera(camera);
+  }
+
+  @ReactProp(name = "initialCamera")
+  public void setInitialCamera(AirMapView view, ReadableMap initialCamera) {
+    view.setInitialCamera(initialCamera);
+  }
+
   @ReactProp(name = "mapType")
   public void setMapType(AirMapView view, @Nullable String mapType) {
     int typeId = MAP_TYPES.get(mapType);

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -39,6 +39,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   private static final int SET_MAP_BOUNDARIES = 8;
   private static final int ANIMATE_TO_NAVIGATION = 9; 
   private static final int SET_INDOOR_ACTIVE_LEVEL_INDEX = 10;
+  private static final int SET_CAMERA = 11;
+  private static final int ANIMATE_CAMERA = 12;
 
 
   private final Map<String, Integer> MAP_TYPES = MapBuilder.of(
@@ -262,8 +264,20 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     float bearing;
     float angle;
     ReadableMap region;
+    ReadableMap camera;
 
     switch (commandId) {
+      case SET_CAMERA:
+        camera = args.getMap(0);
+        view.animateToCamera(camera, 0);
+        break;
+
+      case ANIMATE_CAMERA:
+        camera = args.getMap(0);
+        duration = args.getInt(1);
+        view.animateToCamera(camera, duration);
+        break;
+
       case ANIMATE_TO_NAVIGATION:
         region = args.getMap(0);
         lng = region.getDouble("longitude");
@@ -366,6 +380,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   @Override
   public Map<String, Integer> getCommandsMap() {
     Map<String, Integer> map = this.CreateMap(
+        "setCamera", SET_CAMERA,
+        "animateCamera", ANIMATE_CAMERA,
         "animateToRegion", ANIMATE_TO_REGION,
         "animateToCoordinate", ANIMATE_TO_COORDINATE,
         "animateToViewingAngle", ANIMATE_TO_VIEWING_ANGLE,
@@ -385,7 +401,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   }
 
   public static <K, V> Map<K, V> CreateMap(
-  K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8) {
+  K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
     Map map = new HashMap<K, V>();
     map.put(k1, v1);
     map.put(k2, v2);
@@ -394,6 +410,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     map.put(k5, v5);
     map.put(k6, v6);
     map.put(k7, v7);
+    map.put(k8, v8);
+    map.put(k8, v8);
     map.put(k8, v8);
     return map;
   }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -19,6 +19,7 @@ import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 
 import java.io.ByteArrayOutputStream;
@@ -136,6 +137,43 @@ public class AirMapModule extends ReactContextBaseJavaModule {
             }
           }
         });
+      }
+    });
+  }
+
+  @ReactMethod
+  public void getCamera(final int tag, final Promise promise) {
+    final ReactApplicationContext context = getReactApplicationContext();
+
+    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+    uiManager.addUIBlock(new UIBlock()
+    {
+      @Override
+      public void execute(NativeViewHierarchyManager nvhm)
+      {
+        AirMapView view = (AirMapView) nvhm.resolveView(tag);
+        if (view == null) {
+          promise.reject("AirMapView not found");
+          return;
+        }
+        if (view.map == null) {
+          promise.reject("AirMapView.map is not valid");
+          return;
+        }
+
+        CameraPosition position = view.map.getCameraPosition();
+
+        WritableMap centerJson = new WritableNativeMap();
+        centerJson.putDouble("latitude", position.target.latitude);
+        centerJson.putDouble("longitude", position.target.longitude);
+
+        WritableMap cameraJson = new WritableNativeMap();
+        cameraJson.putMap("center", centerJson);
+        cameraJson.putDouble("heading", (double)position.bearing);
+        cameraJson.putDouble("zoom", (double)position.zoom);
+        cameraJson.putDouble("pitch", (double)position.tilt);
+
+        promise.resolve(cameraJson);
       }
     });
   }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -695,6 +695,33 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
   }
 
+  public void animateToCamera(ReadableMap camera, int duration) {
+    if (map == null) return;
+    CameraPosition.Builder builder = new CameraPosition.Builder(map.getCameraPosition());
+    if (camera.hasKey("zoom")) {
+      builder.zoom((float)camera.getDouble("zoom"));
+    }
+    if (camera.hasKey("heading")) {
+      builder.bearing((float)camera.getDouble("heading"));
+    }
+    if (camera.hasKey("pitch")) {
+      builder.tilt((float)camera.getDouble("pitch"));
+    }
+    if (camera.hasKey("center")) {
+      ReadableMap center = camera.getMap("center");
+      builder.target(new LatLng(center.getDouble("latitude"), center.getDouble("longitude")));
+    }
+
+    CameraUpdate update = CameraUpdateFactory.newCameraPosition(builder.build());
+
+    if (duration <= 0) {
+      map.moveCamera(update);
+    }
+    else {
+      map.animateCamera(update, duration, null);
+    }
+  }
+
   public void animateToNavigation(LatLng location, float bearing, float angle, int duration) {
     if (map == null) return;
     CameraPosition cameraPosition = new CameraPosition.Builder(map.getCameraPosition())

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -83,11 +83,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   private final int baseMapPadding = 50;
 
   private LatLngBounds boundsToMove;
+  private CameraUpdate cameraToSet;
   private boolean showUserLocation = false;
   private boolean handlePanDrag = false;
   private boolean moveOnMarkerPress = true;
   private boolean cacheEnabled = false;
   private boolean initialRegionSet = false;
+  private boolean initialCameraSet = false;
   private LatLngBounds cameraLastIdleBounds;
   private int cameraMoveReason = 0;
 
@@ -426,6 +428,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
   }
 
+  public void setInitialCamera(ReadableMap initialCamera) {
+    if (!initialCameraSet && initialCamera != null) {
+      setCamera(initialCamera);
+      initialCameraSet = true;
+    }
+  }
+
   public void setRegion(ReadableMap region) {
     if (region == null) return;
 
@@ -447,6 +456,35 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     } else {
       map.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0));
       boundsToMove = null;
+    }
+  }
+
+  public void setCamera(ReadableMap camera) {
+    if (camera == null) return;
+
+    CameraPosition.Builder builder = new CameraPosition.Builder();
+
+    ReadableMap center = camera.getMap("center");
+    if (center != null) {
+      Double lng = center.getDouble("longitude");
+      Double lat = center.getDouble("latitude");
+      builder.target(new LatLng(lat, lng));
+    }
+
+    builder.tilt((float)camera.getDouble("pitch"));
+    builder.bearing((float)camera.getDouble("heading"));
+    builder.zoom(camera.getInt("zoom"));
+
+    CameraUpdate update = CameraUpdateFactory.newCameraPosition(builder.build());
+
+    if (super.getHeight() <= 0 || super.getWidth() <= 0) {
+      // in this case, our map has not been laid out yet, so we save the camera update in a
+      // local variable. As soon as layout occurs, we will move the camera to the saved update.
+      // Note that if we tried to move to the camera now, it would trigger an exception.
+      cameraToSet = update;
+    } else {
+      map.moveCamera(update);
+      cameraToSet = null;
     }
   }
 
@@ -649,6 +687,11 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       }
 
       boundsToMove = null;
+      cameraToSet = null;
+    }
+    else if (cameraToSet != null) {
+      map.moveCamera(cameraToSet);
+      cameraToSet = null;
     }
   }
 

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -61,7 +61,7 @@ const CameraShape = PropTypes.shape({
   pitch: PropTypes.number.isRequired,
   heading: PropTypes.number.isRequired,
   altitude: PropTypes.number.isRequired,
-  zoom: PropTypes.number.isRequired
+  zoom: PropTypes.number.isRequired,
 });
 
 

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -49,6 +49,22 @@ const viewConfig = {
   },
 };
 
+
+/**
+ * Defines the map camera.
+ */
+const CameraShape = PropTypes.shape({
+  center: PropTypes.shape({
+    latitude: PropTypes.number.isRequired,
+    longitude: PropTypes.number.isRequired,
+  }),
+  pitch: PropTypes.number.isRequired,
+  heading: PropTypes.number.isRequired,
+  altitude: PropTypes.number.isRequired,
+  zoom: PropTypes.number.isRequired
+});
+
+
 // if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
 const viewPropTypes = ViewPropTypes || View.propTypes;
 
@@ -306,6 +322,27 @@ const propTypes = {
     latitudeDelta: PropTypes.number.isRequired,
     longitudeDelta: PropTypes.number.isRequired,
   }),
+
+  /**
+   * The camera view the map should use.
+   *
+   * Use the camera system, instead of the region system, if you need control over
+   * the pitch or heading.
+   */
+  camera: CameraShape,
+
+  /**
+   * The initial camera view the map should use.  Use this prop instead of `camera`
+   * only if you don't want to control the camera of the map besides the initial view.
+   *
+   * Use the camera system, instead of the region system, if you need control over
+   * the pitch or heading.
+   *
+   * Changing this prop after the component has mounted will not result in a camera change.
+   *
+   * This is similar to the `initialValue` prop of a text input.
+   */
+  initialCamera: CameraShape,
 
   /**
    * A Boolean indicating whether to use liteMode for android

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -595,7 +595,25 @@ class MapView extends React.Component {
     }
   }
 
+  getCamera() {
+    if (Platform.OS === 'android') {
+      return NativeModules.AirMapModule.getCamera(this._getHandle());
+    } else if (Platform.OS === 'ios') {
+      return this._runCommand('getCamera', []);
+    }
+    return Promise.reject('getCamera not supported on this platform');
+  }
+
+  setCamera(camera) {
+    this._runCommand('setCamera', [camera]);
+  }
+
+  animateCamera(camera, opts) {
+    this._runCommand('animateCamera', [camera, opts.duration || 500]);
+  }
+
   animateToNavigation(location, bearing, angle, duration) {
+    console.warn('animateToNavigation() is deprecated, use animateCamera() instead');
     this._runCommand('animateToNavigation', [location, bearing, angle, duration || 500]);
   }
 
@@ -604,14 +622,17 @@ class MapView extends React.Component {
   }
 
   animateToCoordinate(latLng, duration) {
+    console.warn('animateToCoordinate() is deprecated, use animateCamera() instead');
     this._runCommand('animateToCoordinate', [latLng, duration || 500]);
   }
 
   animateToBearing(bearing, duration) {
+    console.warn('animateToBearing() is deprecated, use animateCamera() instead');
     this._runCommand('animateToBearing', [bearing, duration || 500]);
   }
 
   animateToViewingAngle(angle, duration) {
+    console.warn('animateToViewingAngle() is deprecated, use animateCamera() instead');
     this._runCommand('animateToViewingAngle', [angle, duration || 500]);
   }
 

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -609,7 +609,7 @@ class MapView extends React.Component {
   }
 
   animateCamera(camera, opts) {
-    this._runCommand('animateCamera', [camera, opts.duration || 500]);
+    this._runCommand('animateCamera', [camera, (opts && opts.duration) || 500]);
   }
 
   animateToNavigation(location, bearing, angle, duration) {

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -21,6 +21,8 @@
 @property (nonatomic, weak) RCTBridge *bridge;
 @property (nonatomic, assign) MKCoordinateRegion initialRegion;
 @property (nonatomic, assign) MKCoordinateRegion region;
+@property (nonatomic, assign) GMSCameraPosition *cameraProp;   // Because the base class already has a "camera" prop.
+@property (nonatomic, assign) GMSCameraPosition *initialCamera;
 @property (nonatomic, assign) NSString *customMapStyleString;
 @property (nonatomic, assign) UIEdgeInsets mapPadding;
 @property (nonatomic, assign) NSString *paddingAdjustmentBehaviorString;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -57,7 +57,7 @@ id regionAsJSON(MKCoordinateRegion region) {
   NSMutableArray<UIView *> *_reactSubviews;
   MKCoordinateRegion _initialRegion;
   MKCoordinateRegion _region;
-  BOOL _initialRegionSetOnLoad;
+  BOOL _initialCameraSetOnLoad;
   BOOL _didCallOnMapReady;
   BOOL _didMoveToWindow;
 }
@@ -72,9 +72,11 @@ id regionAsJSON(MKCoordinateRegion region) {
     _circles = [NSMutableArray array];
     _tiles = [NSMutableArray array];
     _overlays = [NSMutableArray array];
+    _initialCamera = nil;
+    _cameraProp = nil;
     _initialRegion = MKCoordinateRegionMake(CLLocationCoordinate2DMake(0.0, 0.0), MKCoordinateSpanMake(0.0, 0.0));
     _region = MKCoordinateRegionMake(CLLocationCoordinate2DMake(0.0, 0.0), MKCoordinateSpanMake(0.0, 0.0));
-    _initialRegionSetOnLoad = false;
+    _initialCameraSetOnLoad = false;
     _didCallOnMapReady = false;
     _didMoveToWindow = false;
 
@@ -219,7 +221,10 @@ id regionAsJSON(MKCoordinateRegion region) {
   if (_didMoveToWindow) return;
   _didMoveToWindow = true;
 
-  if (_initialRegion.span.latitudeDelta != 0.0 &&
+  if (_initialCamera != nil) {
+    self.camera = _initialCamera;
+  }
+  else if (_initialRegion.span.latitudeDelta != 0.0 &&
       _initialRegion.span.longitudeDelta != 0.0) {
     self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:_initialRegion];
   } else if (_region.span.latitudeDelta != 0.0 &&
@@ -231,10 +236,17 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 - (void)setInitialRegion:(MKCoordinateRegion)initialRegion {
-  if (_initialRegionSetOnLoad) return;
+  if (_initialCameraSetOnLoad) return;
   _initialRegion = initialRegion;
-  _initialRegionSetOnLoad = _didMoveToWindow;
+  _initialCameraSetOnLoad = _didMoveToWindow;
   self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:initialRegion];
+}
+
+- (void)setInitialCamera:(GMSCameraPosition*)initialCamera {
+    if (_initialCameraSetOnLoad) return;
+    _initialCamera = initialCamera;
+    _initialCameraSetOnLoad = _didMoveToWindow;
+    self.camera = initialCamera;
 }
 
 - (void)setRegion:(MKCoordinateRegion)region {
@@ -242,6 +254,12 @@ id regionAsJSON(MKCoordinateRegion region) {
   _region = region;
   self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self  andMKCoordinateRegion:region];
 }
+
+- (void)setCameraProp:(GMSCameraPosition*)camera {
+    _initialCamera = camera;
+    self.camera = camera;
+}
+
 
 - (void)didPrepareMap {
   if (_didCallOnMapReady) return;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -53,6 +53,8 @@ RCT_EXPORT_MODULE()
   return map;
 }
 
+RCT_EXPORT_VIEW_PROPERTY(initialCamera, GMSCameraPosition)
+RCT_REMAP_VIEW_PROPERTY(camera, cameraProp, GMSCameraPosition)
 RCT_EXPORT_VIEW_PROPERTY(initialRegion, MKCoordinateRegion)
 RCT_EXPORT_VIEW_PROPERTY(region, MKCoordinateRegion)
 RCT_EXPORT_VIEW_PROPERTY(showsBuildings, BOOL)
@@ -86,6 +88,64 @@ RCT_EXPORT_VIEW_PROPERTY(mapType, GMSMapViewType)
 RCT_EXPORT_VIEW_PROPERTY(minZoomLevel, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(maxZoomLevel, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(kmlSrc, NSString)
+
+RCT_EXPORT_METHOD(getCamera:(nonnull NSNumber *)reactTag
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[AIRGoogleMap class]]) {
+            reject(@"Invalid argument", [NSString stringWithFormat:@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view], NULL);
+        } else {
+            AIRGoogleMap *mapView = (AIRGoogleMap *)view;
+            resolve(@{
+                      @"center": @{
+                              @"latitude": @(mapView.camera.target.latitude),
+                              @"longitude": @(mapView.camera.target.longitude),
+                              },
+                      @"pitch": @(mapView.camera.viewingAngle),
+                      @"heading": @(mapView.camera.bearing),
+                      @"zoom": @(mapView.camera.zoom),
+                    });
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber *)reactTag
+                  camera:(id)json)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[AIRGoogleMap class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
+        } else {
+            AIRGoogleMap *mapView = (AIRGoogleMap *)view;
+            GMSCameraPosition *camera = [RCTConvert GMSCameraPositionWithDefaults:json existingCamera:[mapView camera]];
+            [mapView setCamera:camera];
+        }
+    }];
+}
+
+
+RCT_EXPORT_METHOD(animateCamera:(nonnull NSNumber *)reactTag
+                  withCamera:(id)json
+                  withDuration:(CGFloat)duration)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[AIRGoogleMap class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
+        } else {
+            [CATransaction begin];
+            [CATransaction setAnimationDuration:duration/1000];
+            AIRGoogleMap *mapView = (AIRGoogleMap *)view;
+            GMSCameraPosition *camera = [RCTConvert GMSCameraPositionWithDefaults:json existingCamera:[mapView camera]];
+            [mapView animateToCameraPosition:camera];
+            [CATransaction commit];
+        }
+    }];
+}
 
 RCT_EXPORT_METHOD(animateToNavigation:(nonnull NSNumber *)reactTag
                   withRegion:(MKCoordinateRegion)region

--- a/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.h
+++ b/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.h
@@ -11,7 +11,7 @@
 #import <React/RCTConvert.h>
 
 @interface RCTConvert (GMSMapViewType)
-
++ (GMSCameraPosition*)GMSCameraPositionWithDefaults:(id)json existingCamera:(GMSCameraPosition*)existingCamera;
 @end
 
 #endif

--- a/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.m
+++ b/lib/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.m
@@ -9,6 +9,7 @@
 #import "RCTConvert+GMSMapViewType.h"
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
 
 @implementation RCTConvert (GMSMapViewType)
   RCT_ENUM_CONVERTER(GMSMapViewType,
@@ -21,6 +22,58 @@
       @"none": @(kGMSTypeNone)
     }
   ), kGMSTypeTerrain, intValue)
+
+
++ (GMSCameraPosition*)GMSCameraPosition:(id)json
+{
+    json = [self NSDictionary:json];
+    return [RCTConvert GMSCameraPositionWithDefaults:json existingCamera:nil];
+}
+
++ (GMSCameraPosition*)GMSCameraPositionWithDefaults:(id)json existingCamera:(GMSCameraPosition*)existingCamera
+{
+    CLLocationDegrees latitude = 0;
+    CLLocationDegrees longitude = 0;
+    double viewingAngle = 0;
+    double zoom = 0;
+    double bearing = 0;
+
+    if (existingCamera != nil) {
+        viewingAngle = existingCamera.viewingAngle;
+        latitude = existingCamera.target.latitude;
+        longitude = existingCamera.target.longitude;
+        zoom = 0;
+        bearing = 0;
+    }
+
+    if (json[@"center"]) {
+        CLLocationCoordinate2D target = [self CLLocationCoordinate2D:json[@"center"]];
+        latitude = target.latitude;
+        longitude = target.longitude;
+    }
+
+    if (json[@"pitch"]) {
+        viewingAngle = [self double:json[@"pitch"]];
+    }
+
+    // zoomAtCoordinate:forMeters:perPoints is offered by the SDK, which would allow
+    // us to support the "altitude" property of the camera as an alternative to "zoom".
+    // However, I am not clear on what the "perPoints" argument does...
+    if (json[@"zoom"]) {
+        zoom = [self double:json[@"zoom"]];
+    }
+
+    if (json[@"heading"]) {
+        bearing = [self double:json[@"heading"]];
+    }
+
+    return [GMSCameraPosition cameraWithLatitude:latitude
+                                       longitude:longitude
+                                            zoom:zoom
+                                         bearing:bearing
+                                    viewingAngle:viewingAngle];
+}
+
 @end
 
 #endif

--- a/lib/ios/AirMaps/AIRMap.h
+++ b/lib/ios/AirMaps/AIRMap.h
@@ -38,6 +38,7 @@ extern const NSInteger AIRMapMaxZoomLevel;
 @property (nonatomic, assign) UIEdgeInsets legalLabelInsets;
 @property (nonatomic, strong) NSTimer *regionChangeObserveTimer;
 @property (nonatomic, assign) MKCoordinateRegion initialRegion;
+@property (nonatomic, assign) MKMapCamera *initialCamera;
 @property (nonatomic, assign) CGFloat minZoomLevel;
 @property (nonatomic, assign) CGFloat maxZoomLevel;
 

--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -49,6 +49,7 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     UIView *_legalLabel;
     CLLocationManager *_locationManager;
     BOOL _initialRegionSet;
+    BOOL _initialCameraSet;
 
     // Array to manually track RN subviews
     //
@@ -292,6 +293,19 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     if (!_initialRegionSet) {
         _initialRegionSet = YES;
         [self setRegion:initialRegion animated:NO];
+    }
+}
+
+- (void)setCamera:(MKMapCamera*)camera animated:(BOOL)animated
+{
+    [super setCamera:camera animated:animated];
+}
+
+
+- (void)setInitialCamera:(MKMapCamera*)initialCamera {
+    if (!_initialCameraSet) {
+        _initialCameraSet = YES;
+        [self setCamera:initialCamera animated:NO];
     }
 }
 

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -112,6 +112,17 @@ RCT_CUSTOM_VIEW_PROPERTY(initialRegion, MKCoordinateRegion, AIRMap)
     [view setInitialRegion:[RCTConvert MKCoordinateRegion:json]];
     view.ignoreRegionChanges = originalIgnore;
 }
+RCT_CUSTOM_VIEW_PROPERTY(initialCamera, MKMapCamera, AIRMap)
+{
+    if (json == nil) return;
+    
+    // don't emit region change events when we are setting the initialCamera
+    BOOL originalIgnore = view.ignoreRegionChanges;
+    view.ignoreRegionChanges = YES;
+    [view setInitialCamera:[RCTConvert MKMapCamera:json]];
+    view.ignoreRegionChanges = originalIgnore;
+}
+
 
 RCT_EXPORT_VIEW_PROPERTY(minZoomLevel, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(maxZoomLevel, CGFloat)
@@ -125,6 +136,17 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, AIRMap)
     BOOL originalIgnore = view.ignoreRegionChanges;
     view.ignoreRegionChanges = YES;
     [view setRegion:[RCTConvert MKCoordinateRegion:json] animated:NO];
+    view.ignoreRegionChanges = originalIgnore;
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(camera, MKMapCamera*, AIRMap)
+{
+    if (json == nil) return;
+    
+    // don't emit region change events when we are setting the camera
+    BOOL originalIgnore = view.ignoreRegionChanges;
+    view.ignoreRegionChanges = YES;
+    [view setCamera:[RCTConvert MKMapCamera:json] animated:NO];
     view.ignoreRegionChanges = originalIgnore;
 }
 

--- a/lib/ios/AirMaps/RCTConvert+AirMap.h
+++ b/lib/ios/AirMaps/RCTConvert+AirMap.h
@@ -12,6 +12,7 @@
 + (MKCoordinateSpan)MKCoordinateSpan:(id)json;
 + (MKCoordinateRegion)MKCoordinateRegion:(id)json;
 + (MKMapCamera*)MKMapCamera:(id)json;
++ (MKMapCamera*)MKMapCameraWithDefaults:(id)json existingCamera:(MKMapCamera*)camera;
 + (MKMapType)MKMapType:(id)json;
 
 @end

--- a/lib/ios/AirMaps/RCTConvert+AirMap.h
+++ b/lib/ios/AirMaps/RCTConvert+AirMap.h
@@ -11,6 +11,7 @@
 
 + (MKCoordinateSpan)MKCoordinateSpan:(id)json;
 + (MKCoordinateRegion)MKCoordinateRegion:(id)json;
++ (MKMapCamera*)MKMapCamera:(id)json;
 + (MKMapType)MKMapType:(id)json;
 
 @end

--- a/lib/ios/AirMaps/RCTConvert+AirMap.m
+++ b/lib/ios/AirMaps/RCTConvert+AirMap.m
@@ -27,6 +27,18 @@
   };
 }
 
++ (MKMapCamera*)MKMapCamera:(id)json
+{
+    json = [self NSDictionary:json];
+    MKMapCamera *cam = [[MKMapCamera alloc] init];
+    cam.centerCoordinate = [self CLLocationCoordinate2D:json[@"center"]];
+    cam.pitch = [self double:json[@"pitch"]];
+    cam.altitude = [self double:json[@"altitude"]];
+    cam.heading = [self double:json[@"heading"]];
+    return cam;
+}
+
+
 RCT_ENUM_CONVERTER(MKMapType, (@{
   @"standard": @(MKMapTypeStandard),
   @"satellite": @(MKMapTypeSatellite),

--- a/lib/ios/AirMaps/RCTConvert+AirMap.m
+++ b/lib/ios/AirMaps/RCTConvert+AirMap.m
@@ -30,12 +30,30 @@
 + (MKMapCamera*)MKMapCamera:(id)json
 {
     json = [self NSDictionary:json];
-    MKMapCamera *cam = [[MKMapCamera alloc] init];
-    cam.centerCoordinate = [self CLLocationCoordinate2D:json[@"center"]];
-    cam.pitch = [self double:json[@"pitch"]];
-    cam.altitude = [self double:json[@"altitude"]];
-    cam.heading = [self double:json[@"heading"]];
-    return cam;
+    return [RCTConvert MKMapCameraWithDefaults:json existingCamera:nil];
+}
+
++ (MKMapCamera*)MKMapCameraWithDefaults:(id)json existingCamera:(MKMapCamera*)camera
+{
+    json = [self NSDictionary:json];
+    if (camera == nil) {
+        camera = [[MKMapCamera alloc] init];
+    } else {
+        camera = [camera copy];
+    }
+    if (json[@"center"]) {
+        camera.centerCoordinate = [self CLLocationCoordinate2D:json[@"center"]];
+    }
+    if (json[@"pitch"]) {
+        camera.pitch = [self double:json[@"pitch"]];
+    }
+    if (json[@"altitude"]) {
+        camera.altitude = [self double:json[@"altitude"]];
+    }
+    if (json[@"heading"]) {
+        camera.heading = [self double:json[@"heading"]];
+    }
+    return camera;
 }
 
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

There is currently no way to control the camera via props.

### How did you test this PR?

I tested the example that comes with the PR on Android and on iOS with MapKit + Google Maps. I further tested the examples that have been updated as part of the PR on those platforms.

### Proposal

It is currently not possible to control things like the viewing angle, or the bearing, via props. In addition, the set of imperative methods to control the camera as they exist feel to me a bit as if they have grown over time, maybe just focussing on those parts the contributor needed to solve their problem at hand.

On the other hand, both the Apple Maps SDK as well as Google Maps support a flexible powerful camera system, which we can (and should) expose more directly.

One related problem is that the new `animateToNavigation` lacks the ability to set the zoom level (https://github.com/react-community/react-native-maps/pull/2436). The challenge there is that iOS does not support a zoom level in the way Google Maps does - it uses a meter-based altitude measurement instead. 

My suggestion, here (partially) implemented for Apple Maps, is as follows:

```js
// The camera system is an alternative to the region system; it is based on  a center point that 
// we look at. 
type Camera = {
    center: {
       latitude: number,
       longitude: number,
   },
   pitch: number,
   bearing: number
   altitude: number.
   zoom: number
}
<MapView  initialCamera={} />
<MapView  camera={} />

// We can just set the bearing and the pitch, the others remain then at their current value.
mapView.setCamera({
    pitch: 10,
    bearing: 90
})

// Here we animate instead.
mapView.animateCamera({
    pitch: 10,
    bearing: 90
})

// Zoom (for Google) and altitude (for Apple) need to be set set separately.
mapView.animateCamera({
    zoom: 15
    altitude: 1000
})

// We can also allow the camera to be queried:
await mapView.getCamera();
```

This would also allow us to deprecate most of the existing `animateTo*` methods. Whatever you need to do, you can configure the camera to the desired combination of changes.

I would be willing to implement this for all platforms, but wanted to get some feedback first.


@techieyann  @dorshay6 @rborn @christopherdro 


### Current state:

- [x] camera/initial Camera iOS
- [x] camera/initial Camera Android
- [x] camera/initial Camera GoogleMaps iOS
- [x] setCamera/animateCamera iOS
- [x] setCamera/animateCamera Android
- [x] setCamera/animateCamera GoogleMaps iOS
- [x] getCamera iOS
- [x] getCamera Android
- [x] getCamera GoogleMaps iOS
- [x] Example
- [x] Docs

When merged, I believe this would allow us to close #2436 and #2407.
