### PR TITLE
[Android] Fix app crash in Android if building found but cannot getActiveLevelIndex

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -1108,7 +1108,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   
   @Override
   public void onIndoorLevelActivated(IndoorBuilding building) {
+    if (building == null) {
+      return;
+    }
     int activeLevelIndex = building.getActiveLevelIndex();
+    if (activeLevelIndex < 0 || activeLevelIndex >= building.getLevels().size()) {
+      return;
+    }
     IndoorLevel level = building.getLevels().get(activeLevelIndex);
 
     WritableMap event = Arguments.createMap();


### PR DESCRIPTION
Does any other open PR do the same thing?
No, it doesn't.

### What issue is this PR fixing?
Fix Android app crash because building.getActiveLevelIndex() return index that out of bounds of 
 the building when map found a building but showsIndoors is false. Exception error message as below

`Fatal Exception: java.lang.ArrayIndexOutOfBoundsException
length=8; index=-1
java.util.ArrayList.get (ArrayList.java:439)
com.airbnb.android.react.maps.AirMapView.onIndoorLevelActivated (AirMapView.java:1112)`

### How did you test this PR?

Tested on Android emulator (Nexus 5), real Android device (HTC U11),  iOS Simulator (iPhone X), real iOS device (iPhone 6S) by running example.